### PR TITLE
`cheeto slurm clone`

### DIFF
--- a/cheeto/slurm.py
+++ b/cheeto/slurm.py
@@ -149,8 +149,12 @@ class SAcctMgr:
                                 f'account={account_name}',
                                 f'partition={partition_name}')
     
-    def show_associations(self) -> sh.Command:
-        return self.show.bake('associations')
+    def show_associations(self, query: Optional[dict] = None) -> sh.Command:
+        cmd = self.show.bake('associations')
+        if query is not None:
+            query = [f'{k}={v}' for k, v in query.items()]
+            cmd = cmd.bake('where', *query)
+        return cmd
 
     def show_qos(self) -> sh.Command:
         return self.show.bake('qos')
@@ -166,9 +170,9 @@ class SAcctMgr:
         buf.seek(0)
         return build_slurm_qos_state(buf)
 
-    def get_slurm_association_state(self) -> dict:
+    def get_slurm_association_state(self, query: Optional[dict] = None) -> dict:
         buf = StringIO()
-        cmd = self.show_associations()
+        cmd = self.show_associations(query=query)
         cmd(_out=buf)
         buf.seek(0)
         return build_slurm_association_state(buf)
@@ -533,3 +537,5 @@ def audit_partitions(args):
                                                strict=True))
 
 
+def clone(args):
+    pass

--- a/tests/test-data/testuser.txt
+++ b/tests/test-data/testuser.txt
@@ -2,13 +2,14 @@ sponsor:
     accountname: Steven Sponsor
     name: Steven Sponsor
     email: sponsor@ucdavis.edu
-    kerb: sjknapp
+    kerb: jawdat
     iam: 3333333333
     mothra: 03333333
+    cluster: Franklin
 
 account:
     name: Test User
-    email: user@ucdavis.edu
+    email: cswel@ucdavis.edu
     kerb: testuser
     iam: 2222222222
     mothra: 02222222


### PR DESCRIPTION
Enable cloning a group's associations to a user. CLI will be something like:

    cheeto slurm clone --account [account to clone from] --user [user to set associations on] --min-count [minimum number of partition/qos user associations to be eligible for cloning]

This is a holdover utility to allow maintaining Peloton's slurm associations for new users until we can transition the cluster to the a full YAML sync during the fall maintenance window.