### PR TITLE
Create raid1_root_largest_scratch.yaml

### DIFF
--- a/cheeto/templates/layouts/raid1_root_largest_scratch.yaml
+++ b/cheeto/templates/layouts/raid1_root_largest_scratch.yaml
@@ -1,0 +1,119 @@
+{%- extends "user-data.yaml.j2" %}
+{%- block disks %}
+# 3 physical disks: 2 for root, 1 for scratch
+- id: disk-sda
+  match:
+    size: smallest
+  ptable: gpt
+  name: ''
+  grub_device: true
+  type: disk
+  preserve: false
+  wipe: superblock-recursive
+
+- id: disk-sdb
+  match:
+    size: smallest
+  ptable: gpt
+  name: ''
+  grub_device: true
+  type: disk
+  preserve: false
+  wipe: superblock-recursive
+
+- id: disk-sdc
+  match:
+    size: largest
+  ptable: gpt
+  name: ''
+  grub_device: false
+  type: disk
+  preserve: false
+  wipe: superblock-recursive
+
+# Partitions
+# First disk
+- id: partition-a-grub
+  device: disk-sda
+  size: 1048576
+  flag: bios_grub
+  number: 1
+  preserve: false
+  grub_device: false
+  type: partition
+          
+- id: partition-a-root
+  device: disk-sda
+  size: -1
+  flag: linux
+  number: 2
+  preserve: false
+  grub_device: false
+  type: partition
+          
+# Second disk
+- id: partition-b-grub
+  device: disk-sdb
+  size: 1048576
+  flag: bios_grub
+  number: 1
+  preserve: false
+  grub_device: false
+  type: partition
+          
+- id: partition-b-root
+  device: disk-sdb
+  size: -1
+  flag: linux
+  number: 2
+  preserve: false
+  grub_device: false
+  type: partition
+          
+# Third disk
+- id: partition-c-scratch
+  device: disk-sdc
+  size: -1
+  number: 1
+  preserve: false
+  grub_device: false
+  type: partition
+
+# root RAID
+- id: raid-root
+  name: md0
+  raidlevel: raid1
+  devices:
+    - partition-a-root
+    - partition-b-root
+  spare_devices: []
+  preserve: false
+  wipe: superblock
+  metadata: '1.2'
+  type: raid
+
+
+# File-systems
+- id: format-root
+  volume: raid-root
+  fstype: ext4
+  preserve: false
+  type: format
+  
+- id: format-scratch
+  volume: partition-c-scratch
+  fstype: ext4
+  preserve: false
+  type: format
+
+# Mounts
+- id: mount-root
+  device: format-root
+  path: /
+  type: mount
+  
+- id: mount-scratch
+  device: format-scratch
+  path: /scratch
+  type: mount
+{%- endblock disks %}


### PR DESCRIPTION
Add a disk layout that has the 2 smallest drives mirrored for `/` and the largest (single) drive used for `/scratch/`.