### PR TITLE
Add skip_history flag to suppress History inserts

### DIFF
--- a/cheeto/daemon/api.py
+++ b/cheeto/daemon/api.py
@@ -74,7 +74,8 @@ def create_api(config: Config, client=None) -> FastAPI:
         sitename = resolved.name if resolved is not None else None
         blocks = await ExportRootSSHKeys.run(request.app.state.client,
                                              None,
-                                             sitename=sitename)
+                                             sitename=sitename,
+                                             skip_history=True)
         return {'root-ssh-public-keys': root_ssh_keys(blocks)}
 
     @router.get('/puppet/storage/{site}')
@@ -82,7 +83,8 @@ def create_api(config: Config, client=None) -> FastAPI:
                             sitename: str = Depends(resolved_sitename)) -> dict:
         return await ExportPuppetStorage.run(request.app.state.client,
                                              None,
-                                             sitename=sitename)
+                                             sitename=sitename,
+                                             skip_history=True)
 
     api.include_router(router, prefix=_router_prefix(config))
     return api

--- a/cheeto/operations/base.py
+++ b/cheeto/operations/base.py
@@ -49,6 +49,10 @@ class Operation(ABC):
     def __init__(self, client: AsyncMongoClient, author: User | None) -> None:
         self.client = client
         self.author = author
+        # Set per-run via run(skip_history=...). When True, _execute_and_log
+        # skips the History insert but still logs — for frequently-hit
+        # read-only ops (e.g. the API exports) that would otherwise spam it.
+        self.skip_history = False
         self.logger = logging.getLogger(
             f'{__name__}.{self.__class__.__name__}'
         )
@@ -63,12 +67,13 @@ class Operation(ABC):
 
     async def _execute_and_log(self, session: AsyncClientSession) -> Any:
         result = await self.execute(session)
-        await History(
-            op=self.op_name,
-            author=self.author,
-            changes=self.describe(),
-            timestamp=datetime.now(timezone.utc),
-        ).insert(session=session)
+        if not self.skip_history:
+            await History(
+                op=self.op_name,
+                author=self.author,
+                changes=self.describe(),
+                timestamp=datetime.now(timezone.utc),
+            ).insert(session=session)
         self.logger.info(
             '%s by %s: %s',
             self.op_name,
@@ -90,6 +95,8 @@ class Operation(ABC):
                 return await self._execute_and_log(session)
 
     @classmethod
-    async def run(cls, client: AsyncMongoClient, author: User | None, **kwargs: Any) -> Any:
+    async def run(cls, client: AsyncMongoClient, author: User | None,
+                  *, skip_history: bool = False, **kwargs: Any) -> Any:
         op = cls(client, author, **kwargs)
+        op.skip_history = skip_history
         return await op._run()

--- a/cheeto/tests/test_beanie.py
+++ b/cheeto/tests/test_beanie.py
@@ -4491,6 +4491,31 @@ class TestExportRootSSHKeys:
         scoped = await ExportRootSSHKeys.run(beanie_client, None, sitename='g1')
         assert [b.name for b in scoped] == ['g_a']
 
+    async def test_skip_history_suppresses_insert(self, beanie_client):
+        from cheeto.models.history import History
+
+        site = Site(name='rkhist', fqdn='rkhist.test')
+        await site.insert()
+        await self._admin(
+            'rk_h', 80010, access=['login-ssh', 'root-ssh'], site=site,
+            keys=['ssh-ed25519 AAAAh h@host'],
+        )
+
+        # skip_history=True: still returns the blocks, writes no History row.
+        blocks = await ExportRootSSHKeys.run(
+            beanie_client, None, sitename='rkhist', skip_history=True,
+        )
+        assert blocks  # admin with a key -> non-empty
+        assert await History.find_one(
+            History.op == 'export_root_ssh_keys',
+        ) is None
+
+        # Default: the History row is written (the flag is opt-in).
+        await ExportRootSSHKeys.run(beanie_client, None, sitename='rkhist')
+        assert await History.find_one(
+            History.op == 'export_root_ssh_keys',
+        ) is not None
+
 
 class TestLDAPUserRecordSshKeys:
     """The LDAP user projection prefixes every SSH key with the same

--- a/cheeto/tests/test_daemon.py
+++ b/cheeto/tests/test_daemon.py
@@ -685,6 +685,26 @@ class TestDaemonApi:
         assert resp.status_code == 200
         assert 'api_admin' in resp.text
 
+    async def test_export_endpoints_skip_history(
+        self, beanie_client, config, rk_site,
+    ):
+        """The read-only export endpoints must not spam the History collection
+        (they pass skip_history=True)."""
+        api = create_api(config, client=beanie_client)
+        async with _api_client(api) as client:
+            rk = await client.get('/puppet/root-keys/api-site',
+                                  headers={'X-API-Key': 'test-api-key'})
+            st = await client.get('/puppet/storage/api-site',
+                                  headers={'X-API-Key': 'test-api-key'})
+        assert rk.status_code == 200
+        assert st.status_code == 200
+        assert await History.find_one(
+            History.op == 'export_root_ssh_keys',
+        ) is None
+        assert await History.find_one(
+            History.op == 'export_puppet_storage',
+        ) is None
+
     async def test_router_prefix_mounts_routes(
         self, beanie_client, config, rk_site,
     ):


### PR DESCRIPTION

The daemon API's /puppet/root-keys/{site} and /puppet/storage/{site} endpoints run ExportRootSSHKeys / ExportPuppetStorage on every hit (e.g. each Puppet run), and Operation._execute_and_log unconditionally writes a History row. These are read-only exports, so the History collection fills with noise.

Add an opt-in skip_history flag to Operation, threaded through run() as a keyword-only param so no subclass __init__ signatures change. When True, _execute_and_log skips the History.insert but still emits the logger.info line, keeping an operational trace. Both API endpoints pass skip_history=True; the CLI export commands keep writing History (auditable).