### PR TITLE
Insert SSH key from HiPPO CreateAccount events

### DIFF
--- a/cheeto/operations/hippo.py
+++ b/cheeto/operations/hippo.py
@@ -44,7 +44,7 @@ from ..models.user import User
 from .group_membership import AddGroupMember, RemoveGroupMember
 from .group import CreateGroupFromSponsor
 from .storage import CreateHomeStorage
-from .user import AddUserAccess, CreateUser
+from .user import AddUserAccess, AddUserSshKey, CreateUser
 from .user_site import AddSiteUser
 
 
@@ -242,10 +242,18 @@ class CreateAccountHandler(BaseHippoHandler):
 
     async def _ensure_user(self, parsed: ParsedEventContext,
                            context: HippoContext) -> User:
+        # Also applies the SSH key carried on the event: for an existing user we
+        # run an update (replace) op; for a new user CreateUser sets it inline.
+        acct = parsed.hippo_account
+        key = acct.key or None  # Unset / None / '' -> None
         existing = await User.find_one(User.name == parsed.username)
         if existing is not None:
+            if key:
+                await AddUserSshKey.run(
+                    context.client, context.author,
+                    name=parsed.username, key=key, replace=True,
+                )
             return existing
-        acct = parsed.hippo_account
         # HiPPO identities carry mothra/iam ids we could fold into User.iam, but
         # UCDIAMInfo requires both — skip until we cross-walk properly.
         user, _ = await CreateUser.run(
@@ -256,6 +264,7 @@ class CreateAccountHandler(BaseHippoHandler):
             fullname=acct.name,
             gid=int(acct.mothra),
             home_directory=f'/home/{parsed.username}',
+            ssh_key=key,
         )
         return user
 

--- a/cheeto/operations/user.py
+++ b/cheeto/operations/user.py
@@ -101,6 +101,7 @@ class CreateUser(Operation):
         gid: int | None = None,
         home_directory: str | None = None,
         password: str | None = None,
+        ssh_key: str | None = None,
     ) -> None:
         super().__init__(client, author)
         self.name = name
@@ -117,6 +118,8 @@ class CreateUser(Operation):
         self.access = access or []
         self.home_directory = home_directory or f'/home/{name}'
         self.password = password
+        # Collapse '' / whitespace-only to None so we never persist a blank key.
+        self.ssh_key = ssh_key.strip() if ssh_key else None
 
     async def execute(self, session: AsyncClientSession) -> tuple[User, Group]:
         existing = await User.find_one(User.name == self.name)
@@ -154,6 +157,12 @@ class CreateUser(Operation):
         )
         await group.insert(session=session)
 
+        # Persist the SSH key (if any) directly: the SshKey @after_event(Insert)
+        # hook re-dirties the user for LDAP sync. Inlined rather than via
+        # AddUserSshKey so it shares this operation's session/transaction.
+        if self.ssh_key:
+            await SshKey(key=self.ssh_key, user=user).insert(session=session)
+
         self._user = user
         self._group = group
         return user, group
@@ -166,6 +175,7 @@ class CreateUser(Operation):
             'type': self.type,
             'email': self.email,
             'has_password': self.password is not None,
+            'has_ssh_key': self.ssh_key is not None,
         }
 
 

--- a/cheeto/tests/test_beanie.py
+++ b/cheeto/tests/test_beanie.py
@@ -996,6 +996,35 @@ class TestCreateUserOp:
         assert user.password != plaintext
         assert user.password.startswith('$y$')
 
+    async def test_create_user_with_ssh_key(self, beanie_client):
+        key = 'ssh-ed25519 AAAA test@host'
+        user, _ = await CreateUser.run(
+            beanie_client, None,
+            name='keyopuser', email='key@test.com', uid=41600,
+            fullname='Key Op User', ssh_key=key,
+        )
+        keys = await SshKey.find(SshKey.user.id == user.id).to_list()
+        assert len(keys) == 1
+        assert keys[0].key == key
+
+    async def test_create_user_without_ssh_key(self, beanie_client):
+        user, _ = await CreateUser.run(
+            beanie_client, None,
+            name='nokeyuser', email='nokey@test.com', uid=41601,
+            fullname='No Key User',
+        )
+        keys = await SshKey.find(SshKey.user.id == user.id).to_list()
+        assert keys == []
+
+    async def test_create_user_blank_ssh_key_not_persisted(self, beanie_client):
+        user, _ = await CreateUser.run(
+            beanie_client, None,
+            name='blankkeyuser', email='blank@test.com', uid=41602,
+            fullname='Blank Key User', ssh_key='   ',
+        )
+        keys = await SshKey.find(SshKey.user.id == user.id).to_list()
+        assert keys == []
+
 
 class TestUserMutationOps:
 
@@ -7550,13 +7579,19 @@ class TestCreateAccountHomeStorage:
                 home_volume='home', home_quota='20G', home_automount_map='home',
             )
 
-    async def _run_handler(self, beanie_client):
+    def _event_with_key(self, key):
+        """A copy of _EVENT whose sole account carries the given SSH key."""
+        account = dict(self._EVENT['accounts'][0])
+        account['key'] = key
+        return {**self._EVENT, 'accounts': [account]}
+
+    async def _run_handler(self, beanie_client, event=None):
         from ..config import HippoConfig
         from ..hippoapi.models.queued_event_model import QueuedEventModel
         from ..operations.hippo import CreateAccountHandler, HippoContext
         upstream = QueuedEventModel.from_dict({
             'id': 1, 'action': 'CreateAccount', 'status': 'Pending',
-            'data': dict(self._EVENT),
+            'data': dict(event if event is not None else self._EVENT),
         })
         # In-memory record (not inserted) — the handler only stashes attrs on
         # it; the processor owns persistence.
@@ -7595,3 +7630,31 @@ class TestCreateAccountHomeStorage:
         assert await Storage.find_one(
             Storage.name == 'hippouser', Storage.category == 'home',
         ) is None
+
+    async def test_new_user_gets_ssh_key(self, beanie_client):
+        await self._seed_site(beanie_client)
+        key = 'ssh-ed25519 AAAAnewuser hippo@x.test'
+        await self._run_handler(beanie_client, event=self._event_with_key(key))
+        user = await User.find_one(User.name == 'hippouser')
+        keys = await SshKey.find(SshKey.user.id == user.id).to_list()
+        assert [k.key for k in keys] == [key]
+
+    async def test_existing_user_key_replaced(self, beanie_client):
+        await self._seed_site(beanie_client)
+        user, _ = await CreateUser.run(
+            beanie_client, None,
+            name='hippouser', email='hippo@x.test', uid=9990001,
+            fullname='Hippo User', ssh_key='ssh-ed25519 OLDKEY old@host',
+        )
+        new_key = 'ssh-ed25519 AAAAreplacement hippo@x.test'
+        await self._run_handler(beanie_client,
+                                event=self._event_with_key(new_key))
+        keys = await SshKey.find(SshKey.user.id == user.id).to_list()
+        assert [k.key for k in keys] == [new_key]
+
+    async def test_empty_key_not_persisted(self, beanie_client):
+        await self._seed_site(beanie_client)
+        await self._run_handler(beanie_client)   # default _EVENT has key=''
+        user = await User.find_one(User.name == 'hippouser')
+        keys = await SshKey.find(SshKey.user.id == user.id).to_list()
+        assert keys == []


### PR DESCRIPTION
CreateAccountHandler ignored account.key entirely, so a user provisioned via a HiPPO CreateAccount event never got an SSH key in the DB — they wouldn't sync to LDAP with login-ssh and couldn't SSH in until a separate UpdateSshKey event arrived.

Fix both paths in _ensure_user:
- New user: CreateUser now accepts an optional ssh_key and inserts it in the same session (the SshKey @after_event(Insert) hook re-dirties the user for LDAP).
- Existing user: run AddUserSshKey(replace=True), matching UpdateSshKey semantics (HiPPO sends the full current key, so we replace).

acct.key or None maps Unset/None/'' to "no key", so blank keys never persist.