### PR TITLE
Iam sync email fallback

### DIFF
--- a/cheeto/cmds/ng/iam.py
+++ b/cheeto/cmds/ng/iam.py
@@ -23,7 +23,7 @@ from ...operations import (
     SyncAllUsersIAM,
     SyncUserIAM,
 )
-from ...operations.iam import maybe_notify_offboarding
+from ...operations.iam import maybe_notify_offboarding, maybe_notify_restored
 from ...queries import resolve_status_name
 from ...yaml import print_yaml
 from ._args import user_args, yaml_args
@@ -64,9 +64,12 @@ async def iam_sync_cmd(args: Namespace):
             console.print(f'[red]{e}[/]')
             return 1
 
-    with email_notifier(args.config.hippo, enabled=args.notify) as notify:
+    with email_notifier(args.config.hippo, db=args.db, author=args.author,
+                        enabled=args.notify) as notify:
         if await maybe_notify_offboarding(result, notify):
             console.print('[dim]sent offboarding notification[/]')
+        if await maybe_notify_restored(result, notify):
+            console.print('[dim]sent restoration notification[/]')
 
     style = _outcome_style(result.outcome)
     console.print(
@@ -84,7 +87,7 @@ def _(parser: ArgParser):
                         help='Override IAMConfig.expiry_offset_days for this run')
     parser.add_argument('--notify', action='store_true', default=False,
                         help='Email the user if this sync moves them into '
-                             'offboarding')
+                             'offboarding or restores them from it')
 
 
 # ---------------------------------------------------------------------------
@@ -105,7 +108,8 @@ async def iam_sync_all_cmd(args: Namespace):
     types = args.type or list(IAM_SYNCABLE_USER_TYPES)
 
     async with AsyncIAMAPI(cfg) as iam_api:
-        with email_notifier(args.config.hippo, enabled=args.notify) as notify:
+        with email_notifier(args.config.hippo, db=args.db, author=args.author,
+                            enabled=args.notify) as notify:
             tally = await SyncAllUsersIAM.run(
                 args.db, args.author,
                 iam_api=iam_api,
@@ -284,7 +288,8 @@ async def iam_reap_cmd(args: Namespace):
             console.print(f'  [yellow]{u.name}[/] (expires_at={u.expires_at})')
         return
 
-    with email_notifier(args.config.hippo, enabled=args.notify) as notify:
+    with email_notifier(args.config.hippo, db=args.db, author=args.author,
+                        enabled=args.notify) as notify:
         reaped = await ReapOffboardedUsers.run(args.db, args.author,
                                                notifier=notify)
     if not reaped:

--- a/cheeto/daemon/tasks.py
+++ b/cheeto/daemon/tasks.py
@@ -65,7 +65,8 @@ async def _iam_sync(config: Config,
                     author: User | None) -> dict[str, int]:
     tcfg = config.daemon.tasks.iam_sync
     async with AsyncIAMAPI(config.ucdiam) as iam_api:
-        with email_notifier(config.hippo, enabled=tcfg.notify) as notify:
+        with email_notifier(config.hippo, db=client, author=author,
+                            enabled=tcfg.notify) as notify:
             return await SyncAllUsersIAM.run(
                 client, author,
                 iam_api=iam_api,
@@ -85,7 +86,8 @@ async def _reap(config: Config,
     # the task is configured and opts in.
     tcfg = config.daemon.tasks.reap
     notify_enabled = tcfg.notify if tcfg is not None else False
-    with email_notifier(config.hippo, enabled=notify_enabled) as notify:
+    with email_notifier(config.hippo, db=client, author=author,
+                        enabled=notify_enabled) as notify:
         return await ReapOffboardedUsers.run(client, author, notifier=notify)
 
 

--- a/cheeto/hippo.py
+++ b/cheeto/hippo.py
@@ -50,10 +50,10 @@ def hippoapi_client(config: HippoConfig, quiet: bool = False) -> AuthenticatedCl
     )
 
 
-async def send_email(mail: Email, client: AuthenticatedClient) -> None:
+async def send_email(mail: Email, client: AuthenticatedClient) -> bool:
     """POST a rendered Email through the HiPPO styled-notification endpoint.
     Logs on failure; never raises on a non-200 (callers treat notification as
-    best-effort)."""
+    best-effort). Returns True iff the endpoint accepted it (HTTP 200)."""
     body = SimpleNotificationModel(
         subject=mail.subject,
         header=mail.header,
@@ -64,17 +64,20 @@ async def send_email(mail: Email, client: AuthenticatedClient) -> None:
     response = await notify_styled.asyncio_detailed(client=client, body=body)
     if response.status_code == 200:
         logger.info('sent email subject=%r to=%r', mail.subject, mail.emails)
-    else:
-        logger.error(
-            'email send failed (status=%d): %s',
-            response.status_code, response.content,
-        )
+        return True
+    logger.error(
+        'email send failed (status=%d): %s',
+        response.status_code, response.content,
+    )
+    return False
 
 
 @contextmanager
 def email_notifier(
     config: HippoConfig,
     *,
+    db: 'AsyncMongoClient',
+    author: 'User | None' = None,
     enabled: bool = True,
     quiet: bool = True,
 ) -> Iterator[Optional[Callable[[Email], Awaitable[None]]]]:
@@ -82,15 +85,20 @@ def email_notifier(
     `None` when `enabled` is False. Centralizes the on/off gate and the client
     lifetime so callers can write::
 
-        with email_notifier(config.hippo, enabled=cfg.notify) as notify:
+        with email_notifier(config.hippo, db=args.db, author=args.author,
+                            enabled=cfg.notify) as notify:
             await SomeOp.run(..., notifier=notify)
-    """
+
+    Every send goes through the `SendUserEmail` operation so the fully-rendered
+    email is recorded in History — hence `db`/`author` (the audit author)."""
     if not enabled:
         yield None
         return
     with hippoapi_client(config, quiet=quiet) as client:
         async def notify(mail: Email) -> None:
-            await send_email(mail, client)
+            # Lazy import: operations.email imports send_email from this module.
+            from .operations.email import SendUserEmail
+            await SendUserEmail.run(db, author, mail=mail, hippo_client=client)
         yield notify
 
 

--- a/cheeto/mail.py
+++ b/cheeto/mail.py
@@ -202,3 +202,20 @@ class AccountDeactivatedEmail(Email):
     @property
     def header(self) -> str:
         return 'Your account has been deactivated'
+
+
+class AccountRestoredEmail(Email):
+
+    def __init__(self, to: list[str] | None = None,
+                       cc: list[str] | None = None,
+                       **kwargs):
+        self.template = 'account-restored.txt.j2'
+        super().__init__(to=to, cc=cc, **kwargs)
+
+    @property
+    def subject(self) -> str:
+        return 'UCD HPC: Account Restored'
+
+    @property
+    def header(self) -> str:
+        return 'Your account has been restored'

--- a/cheeto/operations/__init__.py
+++ b/cheeto/operations/__init__.py
@@ -1,4 +1,5 @@
 from .base import OPERATIONS, Operation, get_operation, operation_names
+from .email import SendUserEmail
 from .site import (
     AddSiteAlias,
     AddStickyGroup,

--- a/cheeto/operations/email.py
+++ b/cheeto/operations/email.py
@@ -1,0 +1,62 @@
+"""SendUserEmail — the audit-logged choke point for every user-facing email.
+
+All user emails (IAM lifecycle notifications and the HiPPO event-handler
+emails) go through this operation so the fully-rendered message — subject,
+header, recipients, and body — is recorded in the History collection. Sending
+is best-effort: a non-200 or transport failure is captured as ``sent=False``
+and still logged, so a failed notification never aborts the sync or handler
+that triggered it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pymongo import AsyncMongoClient
+from pymongo.asynchronous.client_session import AsyncClientSession
+
+from ..hippo import send_email
+from ..hippoapi.client import AuthenticatedClient
+from ..mail import Email
+from ..models.user import User
+from .base import Operation
+
+
+class SendUserEmail(Operation):
+    """Send a rendered `Email` via the HiPPO notification transport and record
+    the full rendered text in History."""
+
+    op_name = 'send_user_email'
+
+    # External, non-rollbackable API I/O; also invoked from inside other,
+    # already-committed flows (IAM sync driver, HiPPO handlers), so it must not
+    # hold a transaction of its own.
+    transactional = False
+
+    def __init__(
+        self,
+        client: AsyncMongoClient,
+        author: User | None,
+        *,
+        mail: Email,
+        hippo_client: AuthenticatedClient,
+    ) -> None:
+        super().__init__(client, author)
+        self.mail = mail
+        self.hippo_client = hippo_client
+        self._sent = False
+
+    async def execute(self, session: AsyncClientSession) -> bool:
+        self._sent = await send_email(self.mail, self.hippo_client)
+        return self._sent
+
+    def describe(self) -> dict[str, Any]:
+        return {
+            'email_type': type(self.mail).__name__,
+            'subject': self.mail.subject,
+            'header': self.mail.header,
+            'to': list(self.mail.emails),
+            'cc': list(self.mail.ccEmails),
+            'body': '\n\n'.join(self.mail.paragraphs()),
+            'sent': self._sent,
+        }

--- a/cheeto/operations/hippo.py
+++ b/cheeto/operations/hippo.py
@@ -18,7 +18,7 @@ from pymongo import AsyncMongoClient
 
 from ..config import HippoConfig
 from ..constants import HIPPO_EVENT_ACTIONS
-from ..hippo import filter_events, hippoapi_client, send_email
+from ..hippo import filter_events, hippoapi_client
 from ..hippoapi import AuthenticatedClient
 from ..hippoapi.api.event_queue import (
     event_queue_pending_events,
@@ -41,6 +41,7 @@ from ..models.group_membership import GroupMembership
 from ..models.hippo import HippoEvent
 from ..models.site import Site
 from ..models.user import User
+from .email import SendUserEmail
 from .group_membership import AddGroupMember, RemoveGroupMember
 from .group import CreateGroupFromSponsor
 from .storage import CreateHomeStorage
@@ -186,7 +187,10 @@ class UpdateSshKeyHandler(AccountHippoHandler):
             sitename=parsed.sitename,
             sitefqdn=sitefqdn,
         )
-        await send_email(mail, context.hippo_client)
+        await SendUserEmail.run(
+            context.client, context.author,
+            mail=mail, hippo_client=context.hippo_client,
+        )
 
 
 class CreateAccountHandler(BaseHippoHandler):
@@ -237,7 +241,10 @@ class CreateAccountHandler(BaseHippoHandler):
 
         if notify:
             mail = await self._build_email(parsed, user, site)
-            await send_email(mail, context.hippo_client)
+            await SendUserEmail.run(
+                context.client, context.author,
+                mail=mail, hippo_client=context.hippo_client,
+            )
         return user
 
     async def _ensure_user(self, parsed: ParsedEventContext,
@@ -388,7 +395,10 @@ class AddAccountToGroupHandler(AccountHippoHandler):
             slurm_accounts=slurm_accounts,
             group_storages=[],
         )
-        await send_email(mail, context.hippo_client)
+        await SendUserEmail.run(
+            context.client, context.author,
+            mail=mail, hippo_client=context.hippo_client,
+        )
 
 
 class RemoveAccountFromGroupHandler(AccountHippoHandler):
@@ -437,7 +447,10 @@ class RemoveAccountFromGroupHandler(AccountHippoHandler):
             sitename=parsed.sitename,
             sponsors=sponsors,
         )
-        await send_email(mail, context.hippo_client)
+        await SendUserEmail.run(
+            context.client, context.author,
+            mail=mail, hippo_client=context.hippo_client,
+        )
 
 
 class CreateGroupHandler(BaseHippoHandler):
@@ -472,7 +485,10 @@ class CreateGroupHandler(BaseHippoHandler):
                 sitename=parsed.sitename,
                 sitefqdn=sitefqdn,
             )
-            await send_email(mail, context.hippo_client)
+            await SendUserEmail.run(
+                context.client, context.author,
+                mail=mail, hippo_client=context.hippo_client,
+            )
         return sponsor, group
 
 

--- a/cheeto/operations/iam.py
+++ b/cheeto/operations/iam.py
@@ -4,7 +4,7 @@ Three ops live here:
 
   - `SyncUserIAM` — single-user sync. Implements the full state machine:
       hit / hit_restored / miss_first / miss_within_grace / miss_offboarding /
-      miss_already_expiring / miss_never_seen / no_iam_id.
+      miss_already_expiring / miss_not_active.
   - `SyncAllUsersIAM` — driver that loops `SyncUserIAM` over candidate users
     (filtered to `IAM_SYNCABLE_USER_TYPES` so administrative `system`/`class`/
     `shared` accounts are never touched).
@@ -38,7 +38,12 @@ from ..iam_async import (
     IAMUserPayload,
     build_ucdiam_info,
 )
-from ..mail import AccountDeactivatedEmail, AccountOffboardingEmail, Email
+from ..mail import (
+    AccountDeactivatedEmail,
+    AccountOffboardingEmail,
+    AccountRestoredEmail,
+    Email,
+)
 from ..models.user import UCDIAMInfo, User
 from ..queries.access_status import find_status_group, resolve_status_name
 from .base import Operation
@@ -115,6 +120,30 @@ async def maybe_notify_offboarding(
     return True
 
 
+async def maybe_notify_restored(
+    result: SyncUserIAMResult,
+    notifier: Notifier | None,
+) -> bool:
+    """Email a restoration notice when a user just transitioned back out of
+    offboarding (reappeared in IAM). Best-effort, mirroring
+    `maybe_notify_offboarding`: a failed send is logged and reported as False,
+    never propagated. Returns True iff a mail was sent."""
+    if notifier is None or result.outcome != 'hit_restored':
+        return False
+    mail = AccountRestoredEmail(
+        to=[result.email],
+        username=result.username,
+    )
+    try:
+        await notifier(mail)
+    except Exception as e:
+        logger.warning(
+            'restore notification failed for %s: %s', result.username, e,
+        )
+        return False
+    return True
+
+
 class SyncUserIAM(Operation):
     """Sync one user against the IAM API and update their state machine.
 
@@ -145,6 +174,7 @@ class SyncUserIAM(Operation):
         # Filled in by execute() so describe() can report on what happened.
         self._outcome: str = ''
         self._iam_id: int | None = None
+        self._resolved_by: str = ''
         self._expires_at: datetime | None = None
         self._first_missing_at: datetime | None = None
         self._last_seen_at: datetime | None = None
@@ -201,13 +231,23 @@ class SyncUserIAM(Operation):
         if user.iam is not None and user.iam.person is not None:
             iam_id = user.iam.person.iam_id
             self._iam_id = iam_id
+            self._resolved_by = 'cached'
             return await self.iam_api.fetch_user_bundle(iam_id)
 
-        # No cached iam_id (either never synced, or last sync's lookup
-        # didn't produce a person snapshot). Re-resolve.
+        # No cached iam_id (either never synced, or last sync's lookup didn't
+        # produce a person snapshot). Resolve by username, then fall back to
+        # email — some legacy users' system username differs from their IAM
+        # userId. IAM_MISSING only if BOTH miss. (Transient IAM errors raise
+        # out of the resolver and propagate; we never mask them as misses.)
         resolved = await self.iam_api.resolve_iam_id_by_username(user.name)
         if resolved is IAM_MISSING:
-            return IAM_MISSING
+            if user.email:
+                resolved = await self.iam_api.resolve_iam_id_by_email(user.email)
+            if resolved is IAM_MISSING:
+                return IAM_MISSING
+            self._resolved_by = 'email'
+        else:
+            self._resolved_by = 'username'
         iam_id = int(resolved['iamId'])
         self._iam_id = iam_id
         return await self.iam_api.fetch_user_bundle(iam_id)
@@ -252,20 +292,25 @@ class SyncUserIAM(Operation):
 
         elapsed = self.now - iam.first_missing_at
         if elapsed >= timedelta(days=self.grace_days):
-            # Past grace: set expires_at and flip status, but only if we
-            # haven't already set a future expiry (don't clobber operator
-            # work).
+            # Past grace, and no future expiry already pending (don't clobber
+            # operator work). Only a still-active account is moved into the
+            # offboarding window — set its expiry, flip the status, and notify.
+            # Already-inactive/disabled accounts (and accounts already
+            # offboarding) are left to the operator / reaper and are never
+            # (re-)offboarded or notified.
             if user.expires_at is None or user.expires_at <= self.now:
-                user.expires_at = self.now + timedelta(
-                    days=self.expiry_offset_days
-                )
                 current_status = await resolve_status_name(user.status)
                 if current_status == 'active':
+                    user.expires_at = self.now + timedelta(
+                        days=self.expiry_offset_days
+                    )
                     user.status = await find_status_group('offboarding')
                     # Drop per-site status overrides so the effective status
                     # (per-site else global) falls back to global offboarding.
                     await clear_user_site_statuses(user, session)
-                self._outcome = 'miss_offboarding'
+                    self._outcome = 'miss_offboarding'
+                else:
+                    self._outcome = 'miss_not_active'
             else:
                 self._outcome = 'miss_already_expiring'
         else:
@@ -288,6 +333,7 @@ class SyncUserIAM(Operation):
             'username': self.username,
             'outcome': self._outcome,
             'iam_id': self._iam_id,
+            'resolved_by': self._resolved_by,
             'expires_at': _isoformat(self._expires_at),
             'first_missing_at': _isoformat(self._first_missing_at),
             'last_seen_at': _isoformat(self._last_seen_at),
@@ -309,9 +355,11 @@ _TALLY_KEYS = (
     'miss_within_grace',
     'miss_offboarding',
     'miss_already_expiring',
+    'miss_not_active',
     'transient_error',
     'error',
     'notified_offboarding',
+    'notified_restored',
     'notify_error',
 )
 
@@ -416,6 +464,12 @@ class SyncAllUsersIAM(Operation):
         if result.outcome == 'miss_offboarding' and self.notifier is not None:
             if await maybe_notify_offboarding(result, self.notifier):
                 self._tally['notified_offboarding'] += 1
+            else:
+                self._tally['notify_error'] += 1
+
+        if result.outcome == 'hit_restored' and self.notifier is not None:
+            if await maybe_notify_restored(result, self.notifier):
+                self._tally['notified_restored'] += 1
             else:
                 self._tally['notify_error'] += 1
 

--- a/cheeto/templates/emails/account-deactivated.txt.j2
+++ b/cheeto/templates/emails/account-deactivated.txt.j2
@@ -2,6 +2,9 @@ Your UC Davis HPC account **{{ username }}** has reached the end of its
 offboarding window and has been deactivated. You no longer have access to the
 HPC clusters.
 
+If you need to continue using HPC@UCD resources, please work with your sponsor(s) to request
+Temporary Affiliate status (https://taf.ucdavis.edu/).
+
 If you believe this is an error, or you have regained an active campus
 affiliation, please contact
 [hpc-help@ucdavis.edu](mailto:hpc-help@ucdavis.edu?subject=Account%20Reactivation%3A%20{{username}})

--- a/cheeto/templates/emails/account-restored.txt.j2
+++ b/cheeto/templates/emails/account-restored.txt.j2
@@ -1,0 +1,7 @@
+Your UC Davis HPC account **{{ username }}** has reappeared in the campus
+identity system (IAM) and has been restored. The pending deactivation has been
+cancelled and your access to the HPC clusters has been reinstated.
+
+No action is needed on your part. If you believe you received this message in
+error, please contact
+[hpc-help@ucdavis.edu](mailto:hpc-help@ucdavis.edu?subject=Account%20Restored%3A%20{{username}}).

--- a/cheeto/templates/emails/offboarding-warning.txt.j2
+++ b/cheeto/templates/emails/offboarding-warning.txt.j2
@@ -6,7 +6,9 @@ Your account is scheduled to be deactivated on **{{ deactivation_date }}**. Afte
 that date you will lose access to the clusters and your data may eventually be
 removed.
 
+If you need to continue using HPC@UCD resources after leaving the university, 
+please work with your sponsor(s) to request Temporary Affiliate status (https://taf.ucdavis.edu/).
+
 If you believe this is an error — for example, you still have an active campus
-affiliation — please contact
-[hpc-help@ucdavis.edu](mailto:hpc-help@ucdavis.edu?subject=Account%20Offboarding%3A%20{{username}})
+affiliation — please contact [hpc-help@ucdavis.edu](mailto:hpc-help@ucdavis.edu?subject=Account%20Offboarding%3A%20{{username}})
 as soon as possible so we can restore your account before it is deactivated.

--- a/cheeto/tests/test_iam_sync.py
+++ b/cheeto/tests/test_iam_sync.py
@@ -28,7 +28,11 @@ from ..iam_async import (
     IAMUserPayload,
     build_ucdiam_info,
 )
-from ..mail import AccountDeactivatedEmail, AccountOffboardingEmail
+from ..mail import (
+    AccountDeactivatedEmail,
+    AccountOffboardingEmail,
+    AccountRestoredEmail,
+)
 from ..models import ALL_MODELS
 from ..models.group import Group
 from ..models.history import History
@@ -125,6 +129,8 @@ def make_iam_handler(
     person: list[dict] | None = None,
     associations: list[dict] | None = None,
     division: dict[str, list[dict]] | None = None,
+    prikerb: list[dict] | None = None,
+    contact: list[dict] | None = None,
     person_status: int = 200,
     raise_transport: bool = False,
     on_request: Callable[[httpx.Request], None] | None = None,
@@ -134,6 +140,10 @@ def make_iam_handler(
     `person` / `associations` are lists of result dicts to return (or None to
     return an empty results list, which IAM uses for 'definitively missing').
     `division` maps orgOId -> result list.
+    `prikerb` overrides the username (prikerbacct) search results; defaults to
+    `person` for backward compatibility. `contact` is the contact-info (email)
+    search results; defaults to empty so the username path is exercised unless
+    a test opts into the email fallback.
     `person_status` lets a test exercise a non-200 response on get_person.
     """
     division = division or {}
@@ -145,7 +155,11 @@ def make_iam_handler(
             raise httpx.ConnectError('mock transport error')
         path = request.url.path
         if '/iam/people/prikerbacct/search' in path:
-            return _iam_response(person or [])
+            results = prikerb if prikerb is not None else (person or [])
+            return _iam_response(results)
+        # Must precede the generic /iam/people/ (get_person) branch below.
+        if '/iam/people/contactinfo/search' in path:
+            return _iam_response(contact or [])
         if path.startswith('/iam/people/'):
             # /iam/people/{iam_id}
             if person_status != 200:
@@ -338,6 +352,67 @@ class TestSyncUserIAM:
         assert fetched.iam.first_missing_at is None
         assert fetched.expires_at is None
 
+    async def test_resolve_falls_back_to_email(self, beanie_client, make_user):
+        # Legacy user whose system username does not match their IAM userId:
+        # the username search misses but the email (contact-info) search hits.
+        await make_user(name='legacy', uid=10010)
+        handler = make_iam_handler(
+            prikerb=[],                          # username search misses
+            contact=[{'iamId': '1000000001'}],   # email search hits
+            person=[PERSON_JANE],
+            associations=[],
+            division={},
+        )
+        now = datetime(2026, 5, 1)
+        async with make_iam_api(handler) as api:
+            result = await SyncUserIAM.run(
+                beanie_client, None,
+                username='legacy', iam_api=api,
+                grace_days=14, expiry_offset_days=30, now=now,
+            )
+        assert result.outcome == 'hit'
+
+        fetched = await User.find_one(User.name == 'legacy')
+        assert fetched.iam is not None
+        assert fetched.iam.iam_status == 'present'
+        assert fetched.iam.person.iam_id == 1000000001
+
+        # The History entry records that the email fallback was used.
+        hist = await History.find_one(History.op == 'sync_user_iam')
+        assert hist is not None
+        assert hist.changes['resolved_by'] == 'email'
+
+    async def test_resolve_both_miss_starts_streak(self, beanie_client, make_user):
+        # Neither username nor email resolves -> IAM_MISSING -> miss_first.
+        await make_user(name='ghost', uid=10011)
+        handler = make_iam_handler(prikerb=[], contact=[])
+        now = datetime(2026, 5, 1)
+        async with make_iam_api(handler) as api:
+            result = await SyncUserIAM.run(
+                beanie_client, None,
+                username='ghost', iam_api=api,
+                grace_days=14, expiry_offset_days=30, now=now,
+            )
+        assert result.outcome == 'miss_first'
+
+    async def test_resolve_by_username_records_resolved_by(
+        self, beanie_client, make_user,
+    ):
+        # Username hit (no email fallback needed) -> resolved_by == 'username'.
+        await make_user(name='jdoe', uid=10012)
+        handler = make_iam_handler(
+            person=[PERSON_JANE], associations=[], division={},
+        )
+        now = datetime(2026, 5, 1)
+        async with make_iam_api(handler) as api:
+            await SyncUserIAM.run(
+                beanie_client, None,
+                username='jdoe', iam_api=api,
+                grace_days=14, expiry_offset_days=30, now=now,
+            )
+        hist = await History.find_one(History.op == 'sync_user_iam')
+        assert hist.changes['resolved_by'] == 'username'
+
     async def test_hit_restored_from_offboarding(self, beanie_client, make_user):
         from ..models.user import UCDIAMInfo
         now = datetime(2026, 5, 1)
@@ -489,6 +564,42 @@ class TestSyncUserIAM:
         usi = await UserSiteInfo.find_one(UserSiteInfo.user.id == user.id)
         assert usi.status is None
 
+    @pytest.mark.parametrize('status_name', ['inactive', 'disabled'])
+    async def test_miss_non_active_not_offboarded(
+        self, beanie_client, make_user, status_name,
+    ):
+        # A non-active account that goes missing past grace must NOT be
+        # offboarded or notified: outcome is miss_not_active, and neither the
+        # status nor expires_at changes (only the missing bookkeeping advances).
+        from ..models.user import UCDIAMInfo
+        now = datetime(2026, 5, 1)
+        first_missed = now - timedelta(days=20)
+        user = await make_user(
+            name=f'{status_name}user', uid=10100,
+            status=status_name,
+            iam=UCDIAMInfo(
+                iam_status='missing',
+                person=UCDIAMPerson(iam_id=1000000001, mothra_id=1000001),
+                first_missing_at=first_missed,
+            ),
+        )
+        handler = make_iam_handler(person_status=404)
+        async with make_iam_api(handler) as api:
+            result = await SyncUserIAM.run(
+                beanie_client, None,
+                username=user.name, iam_api=api,
+                grace_days=14, expiry_offset_days=30, now=now,
+            )
+        assert result.outcome == 'miss_not_active'
+
+        fetched = await User.find_one(
+            User.name == user.name, fetch_links=True, nesting_depth=1,
+        )
+        assert fetched.status.status_name == status_name   # unchanged
+        assert fetched.expires_at is None                  # not armed
+        assert fetched.iam.iam_status == 'missing'         # bookkeeping advanced
+        assert fetched.iam.first_missing_at == first_missed
+
     async def test_miss_already_expiring(self, beanie_client, make_user):
         from ..models.user import UCDIAMInfo
         now = datetime(2026, 5, 1)
@@ -550,7 +661,7 @@ class TestSyncUserIAM:
         because mongo round-trips datetimes as naive.
         """
         first_missed = datetime(2026, 4, 20)
-        await make_user(iam=UCDIAMInfo(
+        await make_user(status='active', iam=UCDIAMInfo(
             iam_status='missing',
             person=UCDIAMPerson(iam_id=1000000001, mothra_id=1000001),
             first_missing_at=first_missed,
@@ -564,7 +675,7 @@ class TestSyncUserIAM:
                 grace_days=14, expiry_offset_days=30,
             )
         # 'now' will be roughly today; the streak we preloaded is older
-        # than 14 days, so we should have flipped to offboarding.
+        # than 14 days, so the active user should have flipped to offboarding.
         assert result.outcome in {'miss_within_grace', 'miss_offboarding'}
 
     async def test_resolver_hits_but_get_person_misses_records_streak(
@@ -941,6 +1052,77 @@ class TestSyncAllUsersIAMNotify:
         assert fetched.status.status_name == 'offboarding'
         assert fetched.expires_at == now + timedelta(days=30)
 
+    async def test_restored_sends_email(self, beanie_client):
+        now = datetime(2026, 5, 1)
+        # Offboarding user with a future expiry and a cached IAM person who now
+        # reappears in IAM -> restored, and a restoration email is sent.
+        await User(
+            name='returner', email='returner@example.edu', uid=40010, gid=40010,
+            fullname='Returner', home_directory='/home/returner', type='user',
+            status=await status_link('offboarding'),
+            expires_at=now + timedelta(days=15),
+            iam=UCDIAMInfo(
+                iam_status='missing',
+                person=UCDIAMPerson(iam_id=1000000001, mothra_id=1000001),
+                first_missing_at=now - timedelta(days=20),
+            ),
+        ).insert()
+        sent, notify = _collector()
+
+        handler = make_iam_handler(
+            person=[PERSON_JANE], associations=[], division={},
+        )
+        async with make_iam_api(handler) as api:
+            tally = await SyncAllUsersIAM.run(
+                beanie_client, None,
+                iam_api=api, grace_days=14, expiry_offset_days=30,
+                now=now, notifier=notify,
+            )
+        assert tally['hit_restored'] == 1
+        assert tally['notified_restored'] == 1
+        assert tally['notify_error'] == 0
+
+        assert len(sent) == 1
+        mail = sent[0]
+        assert isinstance(mail, AccountRestoredEmail)
+        assert mail.emails == ['returner@example.edu']
+        assert 'returner' in '\n\n'.join(mail.paragraphs())
+
+    async def test_inactive_missing_sends_no_email(self, beanie_client):
+        now = datetime(2026, 5, 1)
+        # Already-inactive user, missing from IAM past grace: must not be
+        # offboarded or emailed.
+        await User(
+            name='inactiveleaver', email='inactiveleaver@example.edu',
+            uid=40020, gid=40020, fullname='Inactive Leaver',
+            home_directory='/home/inactiveleaver', type='user',
+            status=await status_link('inactive'),
+            iam=UCDIAMInfo(
+                iam_status='missing',
+                person=UCDIAMPerson(iam_id=1000000001, mothra_id=1000001),
+                first_missing_at=now - timedelta(days=20),
+            ),
+        ).insert()
+        sent, notify = _collector()
+
+        handler = make_iam_handler(person_status=404)
+        async with make_iam_api(handler) as api:
+            tally = await SyncAllUsersIAM.run(
+                beanie_client, None,
+                iam_api=api, grace_days=14, expiry_offset_days=30,
+                now=now, notifier=notify,
+            )
+        assert tally['miss_not_active'] == 1
+        assert tally['miss_offboarding'] == 0
+        assert tally['notified_offboarding'] == 0
+        assert sent == []
+
+        fetched = await User.find_one(
+            User.name == 'inactiveleaver', fetch_links=True, nesting_depth=1,
+        )
+        assert fetched.status.status_name == 'inactive'
+        assert fetched.expires_at is None
+
 
 class TestReapOffboardedUsersNotify:
 
@@ -1131,3 +1313,57 @@ class TestCreateUserFromIAM:
                 await create_user_from_iam(
                     beanie_client, None, iam_api=api, identifier='jdoe',
                 )
+
+
+# ---------------------------------------------------------------------------
+# SendUserEmail — audit-logged sending
+# ---------------------------------------------------------------------------
+
+
+class TestSendUserEmail:
+
+    async def test_logs_rendered_email_to_history(self, beanie_client, monkeypatch):
+        from ..operations import SendUserEmail
+
+        captured: list = []
+
+        async def fake_send(mail, client):
+            captured.append(mail)
+            return True
+
+        monkeypatch.setattr('cheeto.operations.email.send_email', fake_send)
+
+        mail = AccountDeactivatedEmail(to=['x@y.test'], username='jdoe')
+        sent = await SendUserEmail.run(
+            beanie_client, None, mail=mail, hippo_client=None,
+        )
+        assert sent is True
+        assert captured == [mail]
+
+        hist = await History.find_one(History.op == 'send_user_email')
+        assert hist is not None
+        assert hist.changes['email_type'] == 'AccountDeactivatedEmail'
+        assert hist.changes['subject'] == 'UCD HPC: Account Deactivated'
+        assert hist.changes['to'] == ['x@y.test']
+        assert hist.changes['cc'] == []
+        assert hist.changes['sent'] is True
+        assert 'jdoe' in hist.changes['body']
+
+    async def test_failed_send_still_logged(self, beanie_client, monkeypatch):
+        from ..operations import SendUserEmail
+
+        async def fake_send(mail, client):
+            return False
+
+        monkeypatch.setattr('cheeto.operations.email.send_email', fake_send)
+
+        mail = AccountDeactivatedEmail(to=['x@y.test'], username='jdoe')
+        sent = await SendUserEmail.run(
+            beanie_client, None, mail=mail, hippo_client=None,
+        )
+        assert sent is False
+
+        hist = await History.find_one(History.op == 'send_user_email')
+        assert hist is not None
+        assert hist.changes['sent'] is False
+        assert 'jdoe' in hist.changes['body']


### PR DESCRIPTION
- Updates IAM sync to use email for fallback if username is not found (legacy accounts sometimes have mismatched HPC/kerb usernames
- Sends an email when access is restored during offboarding
- All email sends are now Operations which go in the audit log
- Makes sure accounts that are already _inactive_ or _disabled_ do not enter the offboarding flow