### PR TITLE
SlurmAccount fixes

### DIFF
--- a/cheeto/cmds/ng/slurm.py
+++ b/cheeto/cmds/ng/slurm.py
@@ -2,7 +2,7 @@ from argparse import Namespace
 from pathlib import Path
 
 from beanie import PydanticObjectId
-from ponderosa import ArgParser
+from ponderosa import ArgParser, arggroup
 from rich.panel import Panel
 from rich.table import Table
 
@@ -15,9 +15,11 @@ from ...models.site import Site
 from ...models.slurm import SlurmAllocation, SlurmPartition, SlurmQOS, SlurmTRES
 from ...operations import (
     AddQOSAllocation,
+    CreateSlurmAccount,
     CreateSlurmAssociation,
     CreateSlurmPartition,
     CreateSlurmQOS,
+    EditSlurmAccount,
     EditSlurmAllocation,
     EditSlurmQOS,
     ProvisionSlurmAllocation,
@@ -35,6 +37,7 @@ from ...queries.slurm import (
     list_qos_at_site,
     partition_at_site,
     qos_at_site,
+    slurm_account_at_site,
     total_tres,
 )
 from ...operations.base import UNSET
@@ -90,6 +93,12 @@ def slurm_qos_cmd(args: Namespace):
 @commands.register('ng', 'slurm', 'association', aliases=['assoc'],
                    help='Slurm association operations')
 def slurm_association_cmd(args: Namespace):
+    pass
+
+
+@commands.register('ng', 'slurm', 'account',
+                   help='Slurm account operations')
+def slurm_account_cmd(args: Namespace):
     pass
 
 
@@ -942,3 +951,154 @@ def _(parser: ArgParser):
                         help='Read current user default accounts from a saved '
                              '`sacctmgr show -P user format=User,DefaultAccount` '
                              'dump instead of the controller (offline preview)')
+
+
+# ---------------------------------------------------------------------------
+# slurm account
+# ---------------------------------------------------------------------------
+
+
+def _account_limit_kwargs(args: Namespace) -> dict:
+    return {
+        'max_user_jobs': args.max_user_jobs,
+        'max_group_jobs': args.max_group_jobs,
+        'max_submit_jobs': args.max_submit_jobs,
+        'max_job_length': args.max_job_length,
+    }
+
+
+@arggroup('slurm account', desc='Slurm account limits and coordinators')
+def slurm_account_args(parser: ArgParser) -> None:
+    parser.add_argument('--max-user-jobs', type=int, default=None,
+                        help='Max concurrent jobs per user (-1 = unlimited)')
+    parser.add_argument('--max-group-jobs', type=int, default=None,
+                        help='Max concurrent jobs for the whole account '
+                             '(-1 = unlimited)')
+    parser.add_argument('--max-submit-jobs', type=int, default=None,
+                        help='Max jobs the account may have queued at once '
+                             '(-1 = unlimited)')
+    parser.add_argument('--max-job-length', default=None,
+                        help='Max wall time per job (e.g. "7-00:00:00"; '
+                             '-1 = unlimited)')
+    parser.add_argument('--coordinator', action='append', default=None,
+                        dest='coordinators', metavar='USERNAME',
+                        help='Account coordinator username (repeatable). On '
+                             'edit, replaces the existing coordinator list.')
+
+
+@group_args.apply(required=True)
+@site_args.apply(required=True)
+@slurm_account_args.apply()
+@commands.register('ng', 'slurm', 'account', 'new',
+                   help='Create the Slurm account for a group on a site')
+async def slurm_account_new(args: Namespace):
+    console = Console()
+    await CreateSlurmAccount.run(
+        args.db, args.author,
+        site_name=args.site, group_name=args.group,
+        coordinators=args.coordinators,
+        **_account_limit_kwargs(args),
+    )
+    console.print(
+        f'Created Slurm account for group [green]{args.group}[/] '
+        f'on site [green]{args.site}[/]'
+    )
+
+
+
+@group_args.apply(required=True)
+@site_args.apply(required=True)
+@slurm_account_args.apply()
+@commands.register('ng', 'slurm', 'account', 'edit',
+                   help="Edit a group's Slurm account limits/coordinators "
+                        'on a site')
+async def slurm_account_edit(args: Namespace):
+    console = Console()
+    await EditSlurmAccount.run(
+        args.db, args.author,
+        site_name=args.site, group_name=args.group,
+        coordinators=args.coordinators,
+        **_account_limit_kwargs(args),
+    )
+    console.print(
+        f'Updated Slurm account for group [green]{args.group}[/] '
+        f'on site [green]{args.site}[/]'
+    )
+
+def _account_to_dict(account) -> dict:
+    limits = account.limits
+    coordinators = [
+        c.name if hasattr(c, 'name') else str(c.ref.id)
+        for c in account.coordinators
+    ]
+    return {
+        'group': account.group.name if hasattr(account.group, 'name') else None,
+        'site': account.site.name if hasattr(account.site, 'name') else None,
+        'limits': {
+            'max_user_jobs': limits.max_user_jobs,
+            'max_group_jobs': limits.max_group_jobs,
+            'max_submit_jobs': limits.max_submit_jobs,
+            'max_job_length': limits.max_job_length,
+        },
+        'coordinators': coordinators,
+    }
+
+
+def _render_account_panel(data: dict) -> Panel:
+    table = Table(show_header=False, box=None, pad_edge=False, padding=(0, 1))
+    table.add_column(style='bold cyan', no_wrap=True)
+    table.add_column()
+    table.add_row('group', str(data['group']))
+    table.add_row('site', str(data['site']))
+    lim = data['limits']
+    table.add_row(
+        'limits',
+        f"max_user_jobs={lim['max_user_jobs']}, "
+        f"max_group_jobs={lim['max_group_jobs']}, "
+        f"max_submit_jobs={lim['max_submit_jobs']}, "
+        f"max_job_length={lim['max_job_length']}",
+    )
+    coords = data['coordinators']
+    table.add_row(
+        'coordinators', ', '.join(coords) if coords else '[dim](none)[/]',
+    )
+    return Panel(
+        table,
+        title=f'[bold]Slurm account:[/] [green]{data["group"]}[/] '
+              f'@ [green]{data["site"]}[/]',
+        border_style='cyan', expand=False,
+    )
+
+
+@group_args.apply(required=True)
+@site_args.apply(required=True)
+@commands.register('ng', 'slurm', 'account', 'show',
+                   help="Show a group's Slurm account on a site")
+async def slurm_account_show(args: Namespace):
+    console = Console()
+    site = await Site.find_one(Site.name == args.site)
+    if site is None:
+        console.print(f'[red]Site {args.site} not found[/]')
+        return 1
+    group = await Group.find_one(Group.name == args.group)
+    if group is None:
+        console.print(f'[red]Group {args.group} not found[/]')
+        return 1
+    account = await slurm_account_at_site(group, site, fetch_links=True)
+    if account is None:
+        console.print(
+            f'[dim](no Slurm account for {args.group} on {args.site})[/]'
+        )
+        return 0
+    data = _account_to_dict(account)
+    if args.yaml:
+        print_yaml(data)
+    else:
+        console.print(_render_account_panel(data))
+    return 0
+
+
+@slurm_account_show.args()
+def _(parser: ArgParser):
+    parser.add_argument('--yaml', action='store_true', default=False,
+                        help='Output as YAML')

--- a/cheeto/models/group.py
+++ b/cheeto/models/group.py
@@ -1,18 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Annotated, Optional
+from typing import Annotated
 
 import pymongo
-from beanie import BackLink
 from pymongo import IndexModel
 from pydantic import Field, field_validator, model_validator
 
 from ..constants import GROUP_TYPES, UINT_MAX
 from .base import BaseDocument
 from .ldap_sync import LDAPSyncable, stable_fingerprint
-
-if TYPE_CHECKING:
-    from .slurm import SlurmAccount
 
 
 class Group(LDAPSyncable, BaseDocument):
@@ -29,12 +25,9 @@ class Group(LDAPSyncable, BaseDocument):
     type: str = 'group'
 
     # Membership is per-site and lives on GroupMembership edges, not here.
-    # See cheeto/models/group_membership.py.
-
-    slurm: Optional[BackLink['SlurmAccount']] = Field(
-        default=None,
-        json_schema_extra={'original_field': 'group'},
-    )
+    # See cheeto/models/group_membership.py. Slurm accounts are per-site and
+    # keyed on (group, site); they are looked up via SlurmAccount, not a
+    # backlink here.
 
     @field_validator('type')
     @classmethod

--- a/cheeto/operations/__init__.py
+++ b/cheeto/operations/__init__.py
@@ -54,9 +54,11 @@ from .group_membership import (
 )
 from .slurm import (
     AddQOSAllocation,
+    CreateSlurmAccount,
     CreateSlurmAssociation,
     CreateSlurmPartition,
     CreateSlurmQOS,
+    EditSlurmAccount,
     EditSlurmAllocation,
     EditSlurmQOS,
     ProvisionSlurmAllocation,

--- a/cheeto/operations/slurm.py
+++ b/cheeto/operations/slurm.py
@@ -37,6 +37,18 @@ from .base import UNSET, Operation
 _QOS_ALLOC_FIELDS = ('group_limits', 'user_limits', 'job_limits')
 
 
+async def _resolve_coordinators(usernames: list[str]) -> list[User]:
+    """Resolve coordinator usernames to User documents (for a SlurmAccount's
+    coordinators list). Raises ValueError on the first unknown username."""
+    out: list[User] = []
+    for name in usernames:
+        user = await User.find_one(User.name == name)
+        if user is None:
+            raise ValueError(f'User {name} does not exist')
+        out.append(user)
+    return out
+
+
 class CreateSlurmPartition(Operation):
     op_name = 'create_slurm_partition'
 
@@ -386,6 +398,161 @@ class EditSlurmQOS(Operation):
         return data
 
 
+class CreateSlurmAccount(Operation):
+    """Create the SlurmAccount for a group on a site — the per-(group, site)
+    container that associations and coordinators attach to. Job limits default
+    to unlimited (-1) and can be changed later via EditSlurmAccount."""
+
+    op_name = 'create_slurm_account'
+
+    def __init__(
+        self,
+        client: AsyncMongoClient,
+        author: User | None,
+        *,
+        site_name: str,
+        group_name: str,
+        max_user_jobs: int | None = None,
+        max_group_jobs: int | None = None,
+        max_submit_jobs: int | None = None,
+        max_job_length: str | None = None,
+        coordinators: list[str] | None = None,
+    ) -> None:
+        super().__init__(client, author)
+        self.site_name = site_name
+        self.group_name = group_name
+        self.max_user_jobs = max_user_jobs
+        self.max_group_jobs = max_group_jobs
+        self.max_submit_jobs = max_submit_jobs
+        self.max_job_length = max_job_length
+        self.coordinators = coordinators or []
+
+    def _limit_overrides(self) -> dict[str, Any]:
+        overrides: dict[str, Any] = {}
+        if self.max_user_jobs is not None:
+            overrides['max_user_jobs'] = self.max_user_jobs
+        if self.max_group_jobs is not None:
+            overrides['max_group_jobs'] = self.max_group_jobs
+        if self.max_submit_jobs is not None:
+            overrides['max_submit_jobs'] = self.max_submit_jobs
+        if self.max_job_length is not None:
+            overrides['max_job_length'] = self.max_job_length
+        return overrides
+
+    async def execute(self, session: AsyncClientSession) -> SlurmAccount:
+        site = await Site.find_one(Site.name == self.site_name)
+        if site is None:
+            raise ValueError(f'Site {self.site_name} does not exist')
+        group = await Group.find_one(Group.name == self.group_name)
+        if group is None:
+            raise ValueError(f'Group {self.group_name} does not exist')
+
+        existing = await SlurmAccount.find_one(
+            SlurmAccount.group.id == group.id,
+            SlurmAccount.site.id == site.id,
+        )
+        if existing is not None:
+            raise ValueError(
+                f'SlurmAccount for group {self.group_name} on site '
+                f'{self.site_name} already exists'
+            )
+
+        limits = SlurmAccountLimits(**self._limit_overrides())
+        coordinators = await _resolve_coordinators(self.coordinators)
+
+        account = SlurmAccount(
+            group=group, site=site, limits=limits, coordinators=coordinators,
+        )
+        await account.insert(session=session)
+        self._account = account
+        return account
+
+    def describe(self) -> dict[str, Any]:
+        return {
+            'site': self.site_name,
+            'group': self.group_name,
+            'limits': self._limit_overrides(),
+            'coordinators': self.coordinators,
+        }
+
+
+class EditSlurmAccount(Operation):
+    """Edit a group's SlurmAccount on a site: update job limits and/or replace
+    the coordinator list. Only the fields passed are changed; passing an empty
+    coordinator list clears the coordinators."""
+
+    op_name = 'edit_slurm_account'
+
+    def __init__(
+        self,
+        client: AsyncMongoClient,
+        author: User | None,
+        *,
+        site_name: str,
+        group_name: str,
+        max_user_jobs: int | None = None,
+        max_group_jobs: int | None = None,
+        max_submit_jobs: int | None = None,
+        max_job_length: str | None = None,
+        coordinators: list[str] | None = None,
+    ) -> None:
+        super().__init__(client, author)
+        self.site_name = site_name
+        self.group_name = group_name
+        self.max_user_jobs = max_user_jobs
+        self.max_group_jobs = max_group_jobs
+        self.max_submit_jobs = max_submit_jobs
+        self.max_job_length = max_job_length
+        # None => leave coordinators untouched; [] => clear them.
+        self.coordinators = coordinators
+
+    async def execute(self, session: AsyncClientSession) -> SlurmAccount:
+        site = await Site.find_one(Site.name == self.site_name)
+        if site is None:
+            raise ValueError(f'Site {self.site_name} does not exist')
+        group = await Group.find_one(Group.name == self.group_name)
+        if group is None:
+            raise ValueError(f'Group {self.group_name} does not exist')
+        account = await SlurmAccount.find_one(
+            SlurmAccount.group.id == group.id,
+            SlurmAccount.site.id == site.id,
+        )
+        if account is None:
+            raise ValueError(
+                f'No SlurmAccount for group {self.group_name} on site '
+                f'{self.site_name}'
+            )
+
+        if self.max_user_jobs is not None:
+            account.limits.max_user_jobs = self.max_user_jobs
+        if self.max_group_jobs is not None:
+            account.limits.max_group_jobs = self.max_group_jobs
+        if self.max_submit_jobs is not None:
+            account.limits.max_submit_jobs = self.max_submit_jobs
+        if self.max_job_length is not None:
+            account.limits.max_job_length = self.max_job_length
+        if self.coordinators is not None:
+            account.coordinators = await _resolve_coordinators(self.coordinators)
+
+        await account.save(session=session)
+        self._account = account
+        return account
+
+    def describe(self) -> dict[str, Any]:
+        data: dict[str, Any] = {'site': self.site_name, 'group': self.group_name}
+        if self.max_user_jobs is not None:
+            data['max_user_jobs'] = self.max_user_jobs
+        if self.max_group_jobs is not None:
+            data['max_group_jobs'] = self.max_group_jobs
+        if self.max_submit_jobs is not None:
+            data['max_submit_jobs'] = self.max_submit_jobs
+        if self.max_job_length is not None:
+            data['max_job_length'] = self.max_job_length
+        if self.coordinators is not None:
+            data['coordinators'] = self.coordinators
+        return data
+
+
 class RemoveSlurmPartition(Operation):
     op_name = 'remove_slurm_partition'
 
@@ -630,6 +797,7 @@ class ProvisionSlurmAllocation(Operation):
         self.priority = priority
         self.flags = flags or ['DenyOnLimit']
         self.created_qos = False
+        self.created_account = False
 
     async def execute(self, session: AsyncClientSession) -> SlurmAssociation:
         site = await Site.find_one(Site.name == self.site_name)
@@ -645,9 +813,12 @@ class ProvisionSlurmAllocation(Operation):
             SlurmAccount.site.id == site.id,
         )
         if account is None:
-            raise ValueError(
-                f'No SlurmAccount for {self.account_group_name} on {self.site_name}'
-            )
+            # Provisioning implies the group should have an account here; create
+            # a default one (unlimited limits, no coordinators) rather than
+            # failing. Limits/coordinators can be set later via EditSlurmAccount.
+            account = SlurmAccount(group=group, site=site)
+            await account.insert(session=session)
+            self.created_account = True
         partition = await SlurmPartition.find_one(
             SlurmPartition.name == self.partition_name,
             SlurmPartition.site.id == site.id,
@@ -703,6 +874,7 @@ class ProvisionSlurmAllocation(Operation):
             'partition': self.partition_name,
             'qos': self.qos_name,
             'created_qos': self.created_qos,
+            'created_account': self.created_account,
         }
 
 

--- a/cheeto/queries/slurm.py
+++ b/cheeto/queries/slurm.py
@@ -85,6 +85,20 @@ class UserGroupSlurm:
     slurm: GroupSlurm
 
 
+async def slurm_account_at_site(
+    group: Group, site: Site, *, fetch_links: bool = False,
+) -> SlurmAccount | None:
+    """Fetch the SlurmAccount for (group, site), or None. With
+    `fetch_links=True` (nesting_depth=1) the coordinator Users resolve, for
+    display."""
+    return await SlurmAccount.find_one(
+        SlurmAccount.group.id == group.id,
+        SlurmAccount.site.id == site.id,
+        fetch_links=fetch_links,
+        nesting_depth=1 if fetch_links else None,
+    )
+
+
 async def group_slurm_at_site(group: Group, site: Site) -> GroupSlurm | None:
     """Fetch the SlurmAccount and SlurmAssociations for (group, site), or None."""
     account = await SlurmAccount.find_one(

--- a/cheeto/tests/test_beanie.py
+++ b/cheeto/tests/test_beanie.py
@@ -68,9 +68,11 @@ from ..operations import (
     RehomeUser,
     RemoveVolumeAllocation,
     CreateSite,
+    CreateSlurmAccount,
     CreateSlurmAssociation,
     CreateSlurmPartition,
     CreateSlurmQOS,
+    EditSlurmAccount,
     CreateSystemGroup,
     CreateSystemUser,
     CreateUser,
@@ -1856,6 +1858,175 @@ class TestSlurmOps:
             qos_name='prov2-qos',
         )
         assert assoc1.id == assoc2.id
+
+    async def test_create_slurm_account(self, beanie_client, site):
+        await CreateGroup.run(beanie_client, None, name='acct-grp', gid=64400)
+        account = await CreateSlurmAccount.run(
+            beanie_client, None,
+            site_name='slurmsite', group_name='acct-grp',
+        )
+        assert account.id is not None
+
+        from cheeto.models.slurm import SlurmAccount as _SA
+        fetched = await _SA.find_one(_SA.id == account.id)
+        assert fetched.limits.max_user_jobs == -1
+        assert fetched.limits.max_group_jobs == -1
+        assert fetched.limits.max_submit_jobs == -1
+        assert fetched.limits.max_job_length == '-1'
+        assert fetched.coordinators == []
+
+        hist = await History.find_one(History.op == 'create_slurm_account')
+        assert hist is not None
+        assert hist.changes['group'] == 'acct-grp'
+        assert hist.changes['site'] == 'slurmsite'
+
+    async def test_create_slurm_account_with_limits_and_coordinators(
+        self, beanie_client, site,
+    ):
+        await CreateGroup.run(beanie_client, None, name='acct2-grp', gid=64401)
+        await User(
+            name='coorduser', email='coord@test.com', uid=64500, gid=64500,
+            fullname='Coord User', home_directory='/home/coorduser',
+            type='user',
+        ).insert()
+        account = await CreateSlurmAccount.run(
+            beanie_client, None,
+            site_name='slurmsite', group_name='acct2-grp',
+            max_user_jobs=10, max_group_jobs=50, max_submit_jobs=100,
+            max_job_length='7-00:00:00', coordinators=['coorduser'],
+        )
+        from cheeto.models.slurm import SlurmAccount as _SA
+        fetched = await _SA.find_one(
+            _SA.id == account.id, fetch_links=True, nesting_depth=1,
+        )
+        assert fetched.limits.max_user_jobs == 10
+        assert fetched.limits.max_group_jobs == 50
+        assert fetched.limits.max_submit_jobs == 100
+        assert fetched.limits.max_job_length == '7-00:00:00'
+        assert [c.name for c in fetched.coordinators] == ['coorduser']
+
+    async def test_create_slurm_account_duplicate_raises(self, beanie_client, site):
+        await CreateGroup.run(beanie_client, None, name='acctdup-grp', gid=64402)
+        await CreateSlurmAccount.run(
+            beanie_client, None,
+            site_name='slurmsite', group_name='acctdup-grp',
+        )
+        with pytest.raises(ValueError, match='already exists'):
+            await CreateSlurmAccount.run(
+                beanie_client, None,
+                site_name='slurmsite', group_name='acctdup-grp',
+            )
+
+    async def test_create_slurm_account_unknown_coordinator_raises(
+        self, beanie_client, site,
+    ):
+        await CreateGroup.run(beanie_client, None, name='acctnc-grp', gid=64403)
+        with pytest.raises(ValueError, match='does not exist'):
+            await CreateSlurmAccount.run(
+                beanie_client, None,
+                site_name='slurmsite', group_name='acctnc-grp',
+                coordinators=['ghostuser'],
+            )
+
+    async def test_edit_slurm_account(self, beanie_client, site):
+        await CreateGroup.run(beanie_client, None, name='acctedit-grp', gid=64404)
+        for uname, uid in (('c1', 64510), ('c2', 64511)):
+            await User(
+                name=uname, email=f'{uname}@test.com', uid=uid, gid=uid,
+                fullname=uname, home_directory=f'/home/{uname}', type='user',
+            ).insert()
+        await CreateSlurmAccount.run(
+            beanie_client, None,
+            site_name='slurmsite', group_name='acctedit-grp',
+            max_user_jobs=5, coordinators=['c1'],
+        )
+        # Partial limit update + coordinator replace; max_user_jobs untouched.
+        await EditSlurmAccount.run(
+            beanie_client, None,
+            site_name='slurmsite', group_name='acctedit-grp',
+            max_group_jobs=42, coordinators=['c2'],
+        )
+        group = await Group.find_one(Group.name == 'acctedit-grp')
+        from cheeto.models.slurm import SlurmAccount as _SA
+        fetched = await _SA.find_one(
+            _SA.group.id == group.id, fetch_links=True, nesting_depth=1,
+        )
+        assert fetched.limits.max_user_jobs == 5    # unchanged
+        assert fetched.limits.max_group_jobs == 42  # updated
+        assert [c.name for c in fetched.coordinators] == ['c2']  # replaced
+
+    async def test_edit_slurm_account_missing_raises(self, beanie_client, site):
+        await CreateGroup.run(beanie_client, None, name='acctmiss-grp', gid=64405)
+        with pytest.raises(ValueError, match='No SlurmAccount'):
+            await EditSlurmAccount.run(
+                beanie_client, None,
+                site_name='slurmsite', group_name='acctmiss-grp',
+                max_user_jobs=1,
+            )
+
+    async def test_provision_auto_creates_account(self, beanie_client, site):
+        await CreateGroup.run(beanie_client, None, name='provauto-grp', gid=64406)
+        await CreateSlurmPartition.run(
+            beanie_client, None, name='provauto-part', site_name='slurmsite',
+        )
+        # No SlurmAccount seeded — provision must create it. Instantiate the op
+        # directly so we can read `created_account`.
+        op = ProvisionSlurmAllocation(
+            beanie_client, None,
+            site_name='slurmsite', account_group_name='provauto-grp',
+            partition_name='provauto-part',
+        )
+        assoc = await op._run()
+        assert assoc.id is not None
+        assert op.created_account is True
+
+        from cheeto.models.slurm import SlurmAccount as _SA
+        group = await Group.find_one(Group.name == 'provauto-grp')
+        account = await _SA.find_one(
+            _SA.group.id == group.id, _SA.site.id == site.id,
+        )
+        assert account is not None
+
+    async def test_provision_existing_account_not_recreated(
+        self, beanie_client, site,
+    ):
+        group = await CreateGroup.run(
+            beanie_client, None, name='provexist-grp', gid=64407,
+        )
+        from cheeto.models.slurm import SlurmAccount as _SA, SlurmAccountLimits
+        await _SA(group=group, site=site, limits=SlurmAccountLimits()).insert()
+        await CreateSlurmPartition.run(
+            beanie_client, None, name='provexist-part', site_name='slurmsite',
+        )
+        op = ProvisionSlurmAllocation(
+            beanie_client, None,
+            site_name='slurmsite', account_group_name='provexist-grp',
+            partition_name='provexist-part',
+        )
+        await op._run()
+        assert op.created_account is False
+
+    async def test_slurm_account_at_site_query(self, beanie_client, site):
+        from cheeto.queries.slurm import slurm_account_at_site
+        group = await CreateGroup.run(
+            beanie_client, None, name='acctq-grp', gid=64408,
+        )
+        # Miss before creation.
+        assert await slurm_account_at_site(group, site) is None
+
+        await User(
+            name='qcoord', email='qcoord@test.com', uid=64520, gid=64520,
+            fullname='Q Coord', home_directory='/home/qcoord', type='user',
+        ).insert()
+        await CreateSlurmAccount.run(
+            beanie_client, None,
+            site_name='slurmsite', group_name='acctq-grp',
+            coordinators=['qcoord'],
+        )
+        # Hit; with fetch_links the coordinator User resolves.
+        account = await slurm_account_at_site(group, site, fetch_links=True)
+        assert account is not None
+        assert [c.name for c in account.coordinators] == ['qcoord']
 
     async def test_list_qos_and_associations_at_site(self, beanie_client, site):
         from cheeto.queries.slurm import (


### PR DESCRIPTION
- Remove the leftover `Group.slurm` BackLink (models/group.py). It implied a single account per group (wrong — accounts are site-specific) and had no readers. Drop the field and its now-unused imports.
- Add a way to manage SlurmAccounts:
  * CreateSlurmAccount / EditSlurmAccount operations (operations/slurm.py) — manage the account's job limits and coordinators (coordinators are resolved from usernames; edit replaces the list, mirroring EditSlurmQOS.flags).
  * `ng slurm account new|edit|show` subcommands (cmds/ng/slurm.py), with a lean slurm_account_at_site query (queries/slurm.py) backing `show` (--yaml).
  * ProvisionSlurmAllocation now inline-creates a default account when one is missing instead of raising, tracked via `created_account` in the audit log.
