### PR TITLE
Add `storage new group` — provision group storage

### DIFF
--- a/cheeto/cmds/ng/storage.py
+++ b/cheeto/cmds/ng/storage.py
@@ -12,6 +12,7 @@ from ...models.storage import StaticMount, Storage, StorageVolume
 from ...operations import (
     AddVolumeAllocation,
     CreateAutomountMap,
+    CreateGroupStorage,
     CreateHomeStorage,
     CreateStaticMount,
     CreateStorageVolume,
@@ -94,6 +95,62 @@ def _(parser: ArgParser):
                              'this host instead of under a parent volume')
     parser.add_argument('--path', default=None,
                         help='Host path for --host (default: /home/<user>)')
+
+
+# ---------------------------------------------------------------------------
+# `ng storage new group`
+# ---------------------------------------------------------------------------
+
+
+@site_args.apply(required=True)
+@group_args.apply(required=True)
+@commands.register('ng', 'storage', 'new', 'group',
+                   help="Provision a group's shared storage (volume + record) "
+                        'under a parent volume or host')
+async def storage_new_group(args: Namespace):
+    console = Console()
+    try:
+        await CreateGroupStorage.run(
+            args.db, args.author,
+            group_name=args.group, site_name=args.site,
+            owner_name=args.owner,
+            quota=args.quota,
+            parent_volume=args.parent_volume,
+            automount_map=args.automount_map,
+            static_mount=args.static_mount,
+            no_mount=args.no_mount,
+            host=args.host, host_path=args.path,
+        )
+    except ValueError as e:
+        console.print(f'[red]{e}[/]')
+        return 1
+    console.print(
+        f'Created group storage for [green]{args.group}[/] on site {args.site}'
+    )
+
+
+@storage_new_group.args()
+def _(parser: ArgParser):
+    parser.add_argument('--owner', default=None,
+                        help='Owning user (default: the group sponsor at the '
+                             'site; required if there is no single sponsor)')
+    parser.add_argument('--quota', required=True,
+                        help='Quota for the group volume (e.g. 10T)')
+    parser.add_argument('--parent-volume', default=None,
+                        help='Parent volume to provision under (required '
+                             'unless --host is given)')
+    parser.add_argument('--automount-map', default=None,
+                        help="Mount via this automount map (default: a map "
+                             "named 'group' at the site)")
+    parser.add_argument('--static-mount', default=None,
+                        help='Mount via this static mount')
+    parser.add_argument('--no-mount', action='store_true', default=False,
+                        help='Create the storage without a mount mechanism')
+    parser.add_argument('--host', default=None,
+                        help='Escape hatch: create a standalone volume on '
+                             'this host instead of under a parent volume')
+    parser.add_argument('--path', default=None,
+                        help='Host path for --host (default: /group/<group>)')
 
 
 # ---------------------------------------------------------------------------

--- a/cheeto/operations/__init__.py
+++ b/cheeto/operations/__init__.py
@@ -89,6 +89,7 @@ from .puppet import SyncOldPuppet
 from .storage import (
     AddVolumeAllocation,
     CreateAutomountMap,
+    CreateGroupStorage,
     CreateHomeStorage,
     CreateStaticMount,
     CreateStorageVolume,

--- a/cheeto/operations/storage.py
+++ b/cheeto/operations/storage.py
@@ -10,6 +10,7 @@ from pymongo.asynchronous.client_session import AsyncClientSession
 
 from ..models.base import link_target_id
 from ..models.group import Group
+from ..models.group_membership import GroupMembership
 from ..models.site import Site
 from ..models.storage import (
     AutomountMap,
@@ -473,6 +474,263 @@ class CreateHomeStorage(Operation):
         return {
             'user': self.user_name,
             'site': self.site_name,
+            'quota': self.quota,
+            'parent_volume': self.parent_volume,
+            'host': self.host,
+            'mechanism': self._mechanism,
+        }
+
+
+async def _build_group_volume(
+    site: Site, group_name: str, *,
+    quota: str, parent_volume_name: str | None,
+    host: str | None, host_path: str | None,
+) -> StorageVolume:
+    """Build (not insert) the backing StorageVolume for a group's storage.
+
+    Standalone on `host` (named 'group/<group>'), else a child carved under an
+    explicitly-named parent volume (named '<parent>/<group>', backend/host
+    inherited). There is no site group-default, so a parent volume or host is
+    required. The volume carries the group's quota as its sole allocation.
+    """
+    alloc = _make_allocation(quota, 'initial group allocation')
+    if host is not None:
+        return StorageVolume(
+            name=f'group/{group_name}',
+            site=site,
+            backend='zfs',
+            host=host,
+            host_path=host_path or f'/group/{group_name}',
+            allocations=[alloc],
+            **_backend_config_kwargs('zfs'),
+        )
+    if parent_volume_name is None:
+        raise ValueError(
+            'Group storage requires a parent volume or host; pass '
+            'parent_volume/--parent-volume or host/--host'
+        )
+    parent = await _find_volume(site, parent_volume_name)
+    if parent is None:
+        raise ValueError(
+            f'Parent volume {parent_volume_name} does not exist on {site.name}'
+        )
+    return StorageVolume(
+        name=f'{parent.name}/{group_name}',
+        site=site,
+        backend=parent.backend,
+        host=parent.host,
+        host_path=_join_host_path(parent.host_path, group_name),
+        parent=parent,
+        allocations=[alloc],
+        **_backend_config_kwargs(parent.backend),
+    )
+
+
+async def _resolve_group_mount(
+    site: Site, *,
+    automount_map: str | None, static_mount: str | None, no_mount: bool,
+) -> tuple[AutomountMap | None, StaticMount | None]:
+    """Resolve the mount mechanism for a group storage: explicit
+    automount_map/static_mount by name, else the legacy fallback of an
+    AutomountMap named 'group' on the site (mirrors home's 'home' fallback).
+    Returns (amap, smount); (None, None) if no_mount or nothing resolves."""
+    if no_mount:
+        return None, None
+    if automount_map is not None:
+        amap = await AutomountMap.find_one(
+            AutomountMap.name == automount_map,
+            AutomountMap.site.id == site.id,
+        )
+        if amap is None:
+            raise ValueError(
+                f'AutomountMap {automount_map} does not exist on {site.name}'
+            )
+        return amap, None
+    if static_mount is not None:
+        smount = await StaticMount.find_one(
+            StaticMount.name == static_mount,
+            StaticMount.site.id == site.id,
+        )
+        if smount is None:
+            raise ValueError(
+                f'StaticMount {static_mount} does not exist on {site.name}'
+            )
+        return None, smount
+    # Legacy fallback: a map conventionally named 'group'.
+    amap = await AutomountMap.find_one(
+        AutomountMap.name == 'group',
+        AutomountMap.site.id == site.id,
+    )
+    return amap, None
+
+
+async def _provision_group_storage(
+    session: AsyncClientSession, *,
+    site: Site, group: Group, owner: User,
+    quota: str, parent_volume: str | None,
+    automount_map: str | None, static_mount: str | None,
+    no_mount: bool, host: str | None, host_path: str | None,
+) -> tuple[Storage, str]:
+    """Build + insert the group volume and the group-facing Storage record,
+    returning (storage, mechanism_label). The volume insert is pre-checked so a
+    name clash surfaces as a clean ValueError rather than a DuplicateKeyError."""
+    volume = await _build_group_volume(
+        site, group.name, quota=quota, parent_volume_name=parent_volume,
+        host=host, host_path=host_path,
+    )
+    if await _find_volume(site, volume.name) is not None:
+        raise ValueError(
+            f'StorageVolume {volume.name} already exists on {site.name}'
+        )
+    await volume.insert(session=session)
+
+    amap, smount = await _resolve_group_mount(
+        site, automount_map=automount_map, static_mount=static_mount,
+        no_mount=no_mount,
+    )
+    mechanism = 'none'
+    if amap is not None:
+        mechanism = f'automount:{amap.name}'
+    elif smount is not None:
+        mechanism = f'static:{smount.mount_path}'
+
+    storage = Storage(
+        name=group.name,
+        site=site,
+        category='group',
+        owner=owner,
+        group=group,
+        volume=volume,
+        subpath='',
+        automount_map=amap,
+        mount_name=group.name if amap is not None else '',
+        static_mount=smount,
+    )
+    await storage.insert(session=session)
+    return storage, mechanism
+
+
+class CreateGroupStorage(Operation):
+    """Provision a group's shared storage: a StorageVolume (a child under an
+    explicit parent volume, or standalone on a host) plus the group-facing
+    Storage record (category='group', mounted under /group via the site's
+    'group' automount map by default).
+
+    `Storage.owner` is required; it defaults to the group's sponsor at the site
+    (the sponsor-role GroupMembership). If the group has no sponsor there, or
+    more than one, an explicit `owner_name` is required.
+
+    Unlike home storage there are no site-level group defaults, so a parent
+    volume (or host) and a quota must be given.
+    """
+
+    op_name = 'create_group_storage'
+
+    def __init__(
+        self,
+        client: AsyncMongoClient,
+        author: User | None,
+        *,
+        group_name: str,
+        site_name: str,
+        owner_name: str | None = None,
+        quota: str | None = None,
+        parent_volume: str | None = None,
+        automount_map: str | None = None,
+        static_mount: str | None = None,
+        no_mount: bool = False,
+        host: str | None = None,
+        host_path: str | None = None,
+    ) -> None:
+        super().__init__(client, author)
+        if automount_map is not None and static_mount is not None:
+            raise ValueError(
+                'automount_map and static_mount are mutually exclusive'
+            )
+        self.group_name = group_name
+        self.site_name = site_name
+        self.owner_name = owner_name
+        self.quota = quota
+        self.parent_volume = parent_volume
+        self.automount_map = automount_map
+        self.static_mount = static_mount
+        self.no_mount = no_mount
+        self.host = host
+        self.host_path = host_path
+        # Resolved owner name, filled in by execute() for describe().
+        self._owner_name = owner_name or ''
+        self._mechanism = 'none'
+
+    async def _resolve_owner(self, group: Group, site: Site) -> User:
+        if self.owner_name is not None:
+            owner = await User.find_one(User.name == self.owner_name)
+            if owner is None:
+                raise ValueError(f'User {self.owner_name} does not exist')
+            return owner
+        edges = await GroupMembership.find(
+            GroupMembership.group.id == group.id,
+            GroupMembership.site.id == site.id,
+            fetch_links=True,
+        ).to_list()
+        sponsors = [e.user for e in edges if 'sponsor' in e.roles]
+        if len(sponsors) == 1:
+            return sponsors[0]
+        if not sponsors:
+            raise ValueError(
+                f'Group {group.name} has no sponsor on {site.name}; '
+                f'pass an explicit owner (--owner)'
+            )
+        names = ', '.join(sorted(s.name for s in sponsors))
+        raise ValueError(
+            f'Group {group.name} has multiple sponsors on {site.name} '
+            f'({names}); pass an explicit owner (--owner)'
+        )
+
+    async def execute(self, session: AsyncClientSession) -> Storage:
+        if self.quota is None:
+            raise ValueError('Group storage requires a quota')
+        if self.parent_volume is None and self.host is None:
+            raise ValueError(
+                'Group storage requires a parent volume or host; pass '
+                'parent_volume/--parent-volume or host/--host'
+            )
+
+        group = await Group.find_one(
+            Group.name == self.group_name, with_children=True,
+        )
+        if group is None:
+            raise ValueError(f'Group {self.group_name} does not exist')
+
+        site = await _find_site(self.site_name)
+        owner = await self._resolve_owner(group, site)
+        self._owner_name = owner.name
+
+        existing = await Storage.find_one(
+            Storage.name == self.group_name,
+            Storage.site.id == site.id,
+            Storage.category == 'group',
+        )
+        if existing is not None:
+            raise ValueError(
+                f'Group storage for {self.group_name} on {self.site_name} '
+                f'already exists'
+            )
+
+        storage, mechanism = await _provision_group_storage(
+            session, site=site, group=group, owner=owner,
+            quota=self.quota, parent_volume=self.parent_volume,
+            automount_map=self.automount_map, static_mount=self.static_mount,
+            no_mount=self.no_mount, host=self.host, host_path=self.host_path,
+        )
+        self._mechanism = mechanism
+        self._storage = storage
+        return storage
+
+    def describe(self) -> dict[str, Any]:
+        return {
+            'group': self.group_name,
+            'site': self.site_name,
+            'owner': self._owner_name or None,
             'quota': self.quota,
             'parent_volume': self.parent_volume,
             'host': self.host,

--- a/cheeto/tests/test_beanie.py
+++ b/cheeto/tests/test_beanie.py
@@ -63,6 +63,7 @@ from ..operations import (
     CreateAutomountMap,
     CreateGroup,
     CreateGroupFromSponsor,
+    CreateGroupStorage,
     CreateHomeStorage,
     EditVolumeAllocation,
     RehomeUser,
@@ -5679,6 +5680,145 @@ class TestCreateHomeStorageOp:
                 beanie_client, None,
                 user_name='hsuser', site_name='hs_site',
             )
+
+
+class TestCreateGroupStorageOp:
+
+    async def _seed_group_site(self, beanie_client, *, sponsors=('pi',)):
+        """Site with a parent 'groups' volume + a 'group' automount map, a
+        lab group 'glab', and the given sponsor users (added as group
+        sponsors at the site)."""
+        site = Site(name='gs_site', fqdn='gs.test')
+        await site.insert()
+        await _seed_volume(
+            site, name='groups', host='nas5', host_path='/nas5/groups',
+        )
+        await AutomountMap(name='group', site=site, prefix='/group').insert()
+        await CreateGroup.run(beanie_client, None, name='glab', gid=3900001)
+        for i, s in enumerate(sponsors):
+            await CreateUser.run(
+                beanie_client, None,
+                name=s, email=f'{s}@test.com', uid=75000 + i, fullname=s,
+            )
+            await AddGroupSponsor.run(
+                beanie_client, None,
+                group_name='glab', user_name=s, site_name='gs_site',
+            )
+        return await Site.find_one(Site.name == 'gs_site')
+
+    async def test_sponsor_default_and_group_map(self, beanie_client):
+        await self._seed_group_site(beanie_client, sponsors=('pi',))
+        await CreateGroupStorage.run(
+            beanie_client, None,
+            group_name='glab', site_name='gs_site',
+            quota='10T', parent_volume='groups',
+        )
+        volume = await StorageVolume.find_one(
+            StorageVolume.name == 'groups/glab',
+            fetch_links=True, nesting_depth=1,
+        )
+        assert volume is not None
+        assert volume.host == 'nas5'
+        assert volume.host_path == '/nas5/groups/glab'
+        assert volume.quota == '10T'
+        assert volume.parent.name == 'groups'
+
+        fetched = await Storage.find_one(
+            Storage.name == 'glab', Storage.category == 'group',
+            fetch_links=True, nesting_depth=2,
+        )
+        assert fetched.category == 'group'
+        assert fetched.owner.name == 'pi'       # defaulted to the sponsor
+        assert fetched.group.name == 'glab'
+        assert fetched.subpath == ''
+        assert fetched.quota == '10T'
+        assert fetched.mount_path == '/group/glab'
+
+        hist = await History.find_one(History.op == 'create_group_storage')
+        assert hist is not None
+        assert hist.changes['group'] == 'glab'
+        assert hist.changes['owner'] == 'pi'
+
+    async def test_explicit_owner_overrides_sponsor(self, beanie_client):
+        await self._seed_group_site(beanie_client, sponsors=())
+        await CreateUser.run(
+            beanie_client, None,
+            name='ownr', email='o@test.com', uid=75500, fullname='Ownr',
+        )
+        await CreateGroupStorage.run(
+            beanie_client, None,
+            group_name='glab', site_name='gs_site',
+            quota='5T', parent_volume='groups', owner_name='ownr',
+        )
+        fetched = await Storage.find_one(
+            Storage.name == 'glab', Storage.category == 'group',
+            fetch_links=True, nesting_depth=1,
+        )
+        assert fetched.owner.name == 'ownr'
+
+    async def test_no_sponsor_requires_owner(self, beanie_client):
+        await self._seed_group_site(beanie_client, sponsors=())
+        with pytest.raises(ValueError, match='no sponsor'):
+            await CreateGroupStorage.run(
+                beanie_client, None,
+                group_name='glab', site_name='gs_site',
+                quota='5T', parent_volume='groups',
+            )
+
+    async def test_multiple_sponsors_requires_owner(self, beanie_client):
+        await self._seed_group_site(beanie_client, sponsors=('pi1', 'pi2'))
+        with pytest.raises(ValueError, match='multiple sponsors'):
+            await CreateGroupStorage.run(
+                beanie_client, None,
+                group_name='glab', site_name='gs_site',
+                quota='5T', parent_volume='groups',
+            )
+
+    async def test_requires_parent_or_host(self, beanie_client):
+        await self._seed_group_site(beanie_client, sponsors=('pi',))
+        with pytest.raises(ValueError, match='parent volume or host'):
+            await CreateGroupStorage.run(
+                beanie_client, None,
+                group_name='glab', site_name='gs_site', quota='5T',
+            )
+
+    async def test_requires_quota(self, beanie_client):
+        await self._seed_group_site(beanie_client, sponsors=('pi',))
+        with pytest.raises(ValueError, match='requires a quota'):
+            await CreateGroupStorage.run(
+                beanie_client, None,
+                group_name='glab', site_name='gs_site',
+                parent_volume='groups',
+            )
+
+    async def test_duplicate_group_storage_errors(self, beanie_client):
+        await self._seed_group_site(beanie_client, sponsors=('pi',))
+        await CreateGroupStorage.run(
+            beanie_client, None,
+            group_name='glab', site_name='gs_site',
+            quota='10T', parent_volume='groups',
+        )
+        with pytest.raises(ValueError, match='already exists'):
+            await CreateGroupStorage.run(
+                beanie_client, None,
+                group_name='glab', site_name='gs_site',
+                quota='10T', parent_volume='groups',
+            )
+
+    async def test_host_escape_hatch(self, beanie_client):
+        await self._seed_group_site(beanie_client, sponsors=('pi',))
+        await CreateGroupStorage.run(
+            beanie_client, None,
+            group_name='glab', site_name='gs_site',
+            quota='20T', host='nas99',
+        )
+        volume = await StorageVolume.find_one(
+            StorageVolume.name == 'group/glab',
+        )
+        assert volume.host == 'nas99'
+        assert volume.host_path == '/group/glab'
+        assert volume.quota == '20T'
+        assert volume.parent is None
 
 
 class TestRehomeUser:


### PR DESCRIPTION
Adds the missing CLI driver + operation for provisioning a group's shared storage, mirroring the home-storage path:

- CreateGroupStorage operation (operations/storage.py): builds a StorageVolume (child under an explicit --parent-volume, or standalone on --host) and a Storage(category='group', subpath='') mounted under /group. Owner defaults to the group's sponsor at the site (sponsor-role GroupMembership); if there is no single sponsor, an explicit --owner is required. Mount resolves from --automount-map/--static-mount, else a fallback map named 'group' (mirroring home's 'home' fallback). No site group-defaults: a parent/host and quota are required. Exported from operations/__init__.py.
- `ng storage new group` command (cmds/ng/storage.py) mirroring `new home`.
- TestCreateGroupStorageOp: sponsor default + /group mount, explicit owner, zero/multiple-sponsor errors, missing parent-or-host, missing quota, duplicate guard, and the --host escape hatch.

Full suite: 505 passed, 11 skipped.