### PR TITLE
Fix LDAP password sync: {CRYPT} prefix, clear-on-unset, visibility

### DIFF
--- a/cheeto/cmds/ng/ldap.py
+++ b/cheeto/cmds/ng/ldap.py
@@ -484,6 +484,15 @@ def ldap_show_cmd(args: Namespace):
     pass
 
 
+def _password_display(password: str | None) -> str:
+    """Presence + scheme only — the hash itself must never be printed."""
+    if not password:
+        return 'not set'
+    if password.startswith('{') and '}' in password:
+        return f'set ({password[:password.index("}") + 1]})'
+    return 'set (no scheme!)'
+
+
 @site_args.apply(required=True)
 @user_args.apply(required=True)
 @yaml_args.apply()
@@ -509,6 +518,7 @@ async def ldap_show_user_cmd(args: Namespace):
             'email': record.email,
             'home_directory': record.home_directory,
             'shell': record.shell,
+            'password': _password_display(record.password),
             'ssh_keys': list(record.ssh_keys),
             'memberships': sorted(memberships),
         })
@@ -522,6 +532,11 @@ async def ldap_show_user_cmd(args: Namespace):
     table.add_row('email', record.email)
     table.add_row('home', record.home_directory)
     table.add_row('shell', record.shell)
+    table.add_row(
+        'password',
+        _password_display(record.password) if record.password
+        else '[dim]not set[/]',
+    )
     table.add_row(
         'ssh_keys',
         '\n'.join(record.ssh_keys) if record.ssh_keys else '(none)',

--- a/cheeto/cmds/ng/user.py
+++ b/cheeto/cmds/ng/user.py
@@ -110,6 +110,7 @@ async def _user_to_dict(user: User,
         'shell': user.shell,
         'type': user.type,
         'status': await resolve_status_name(user.status),
+        'has_password': user.password is not None,
         'home_directory': user.home_directory,
         'access': await resolve_access_names(user.access),
         'created_at': user.created_at,
@@ -287,6 +288,12 @@ def _render_user_panel(data: dict) -> Panel:
     for key in scalar_keys:
         if key in data and data[key] is not None:
             table.add_row(key, str(data[key]))
+
+    if 'has_password' in data:
+        table.add_row(
+            'password',
+            'set' if data['has_password'] else '[dim]not set[/]',
+        )
 
     if data.get('access'):
         table.add_row('access', ', '.join(data['access']))

--- a/cheeto/ldap_async.py
+++ b/cheeto/ldap_async.py
@@ -216,6 +216,13 @@ def entry_to_user(entry: LDAPEntry) -> LDAPUserRecord:
     username = _first(entry, 'uid') or ''
     shadow_expire = _first(entry, 'shadowExpire')
 
+    # userPassword has Octet String syntax, so bonsai may hand it back as
+    # bytes; normalize to str. Read-back keeps the wire form ({CRYPT}$y$…)
+    # so callers can report presence/scheme — never display the hash.
+    password = _first(entry, 'userPassword')
+    if isinstance(password, (bytes, bytearray)):
+        password = password.decode(errors='replace')
+
     try:
         expires_at = _days_to_naive_utc(int(shadow_expire)) if shadow_expire is not None else None
     except ValueError:
@@ -234,8 +241,31 @@ def entry_to_user(entry: LDAPEntry) -> LDAPUserRecord:
         ),
         shell=_first(entry, 'loginShell') or '/usr/bin/bash',
         ssh_keys=list(entry.get('sshPublicKey') or ()),
+        password=password,
         expires_at=expires_at,
     )
+
+
+def crypt_password_value(hashed: str) -> str:
+    """Wire format for `userPassword`: slapd needs the RFC-2307 `{CRYPT}`
+    scheme prefix to verify a crypt(3)-style hash (our yescrypt `$y$...`
+    MCF strings) — without it the value is compared as cleartext and every
+    bind fails. Values that already carry a scheme (`{SSHA}...`) pass
+    through untouched. Mongo stores the bare hash; the prefix is applied
+    only at this mapping layer."""
+    if hashed.startswith('{'):
+        return hashed
+    return '{CRYPT}' + hashed
+
+
+# Optional user attributes that `user_to_entry_attrs` omits when unset.
+# `update_user` clears these from the existing entry when absent from the
+# desired attrs, so unsetting a password / removing the last SSH key /
+# clearing an expiry in beanie actually propagates to LDAP. `sn` is NOT
+# here even though the builder can omit it: it is a MUST of inetOrgPerson,
+# so deleting it always fails schema check (and production records always
+# derive a surname).
+_OPTIONAL_USER_ATTRS = ('sshPublicKey', 'userPassword', 'shadowExpire')
 
 
 def user_to_entry_attrs(record: LDAPUserRecord) -> dict[str, list[Any]]:
@@ -255,7 +285,7 @@ def user_to_entry_attrs(record: LDAPUserRecord) -> dict[str, list[Any]]:
     if record.ssh_keys:
         out['sshPublicKey'] = list(record.ssh_keys)
     if record.password is not None:
-        out['userPassword'] = [record.password]
+        out['userPassword'] = [crypt_password_value(record.password)]
     if record.expires_at is not None:
         # RFC 2307: shadowExpire is days since 1970-01-01, as an int string.
         out['shadowExpire'] = [str(_days_since_epoch(record.expires_at))]
@@ -484,11 +514,15 @@ class AsyncLDAPManager:
 
     async def _modify_attrs(
         self, dn: str, attrs: dict[str, list[Any]], *,
+        clear: Iterable[str] = (),
         missing_msg: str,
     ) -> None:
-        """Patch attributes on the existing entry at `dn`. Empty `attrs`
-        no-ops. Raises `LDAPNotFound(missing_msg)` if the entry is gone."""
-        if not attrs:
+        """Patch attributes on the existing entry at `dn`: set everything in
+        `attrs`, then delete each attribute in `clear` that is present on
+        the entry. Empty `attrs` + `clear` no-ops. Raises
+        `LDAPNotFound(missing_msg)` if the entry is gone."""
+        clear = tuple(clear)
+        if not attrs and not clear:
             return
 
         async def _op(conn):
@@ -499,6 +533,9 @@ class AsyncLDAPManager:
                 raise LDAPNotFound(missing_msg)
             for k, v in attrs.items():
                 entry[k] = v
+            for k in clear:
+                if k in entry:
+                    del entry[k]
             await entry.modify()
         await self._pooled_op(_op)
 
@@ -709,11 +746,14 @@ class AsyncLDAPManager:
 
     async def update_user(self, record: LDAPUserRecord) -> None:
         """Patch the user dn to match `record`. Writes everything `add_user`
-        would write minus `objectClass`. Raises `LDAPNotFound` if absent."""
+        would write minus `objectClass`, and clears the optional attributes
+        the record no longer carries (stale password / SSH keys / surname /
+        expiry). Raises `LDAPNotFound` if absent."""
         attrs = user_to_entry_attrs(record)
         attrs.pop('objectClass', None)
         await self._modify_attrs(
             self.user_dn(record.username), attrs,
+            clear=[a for a in _OPTIONAL_USER_ATTRS if a not in attrs],
             missing_msg=f'No such user: {record.username}',
         )
 
@@ -866,7 +906,6 @@ class AsyncLDAPManager:
         out: dict[str, str] = {}
         for record in groups:
             attrs = group_to_entry_attrs(record)
-            print(attrs)
             out[record.groupname] = await self._ensure_entry(
                 self.group_dn(record.groupname), attrs,
             )

--- a/cheeto/tests/conftest.py
+++ b/cheeto/tests/conftest.py
@@ -351,34 +351,88 @@ objectclass ( 1.3.6.1.4.1.24552.500.1.1.2.0
     MAY ( sshPublicKey $ uid ) )
 '''
 
+# Standard autofs/rfc2307bis automount schema — Ubuntu's nis.schema does NOT
+# define automountMap/automount (only the distro autofs-ldap package ships
+# them), so inline the definitions like the LPK schema above. Without these,
+# automountMapName RDNs fail entry adds with "invalid DN".
+_AUTOFS_SCHEMA = '''\
+attributetype ( 1.3.6.1.1.1.1.31
+    NAME 'automountMapName'
+    DESC 'automount Map Name'
+    EQUALITY caseExactIA5Match
+    SUBSTR caseExactIA5SubstringsMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.32
+    NAME 'automountKey'
+    DESC 'Automount Key value'
+    EQUALITY caseExactIA5Match
+    SUBSTR caseExactIA5SubstringsMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE )
+
+attributetype ( 1.3.6.1.1.1.1.33
+    NAME 'automountInformation'
+    DESC 'Automount information'
+    EQUALITY caseExactIA5Match
+    SUBSTR caseExactIA5SubstringsMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE )
+
+objectclass ( 1.3.6.1.1.1.2.16
+    NAME 'automountMap'
+    DESC 'automount Map information'
+    SUP top STRUCTURAL
+    MUST automountMapName
+    MAY description )
+
+objectclass ( 1.3.6.1.1.1.2.17
+    NAME 'automount'
+    DESC 'automount information'
+    SUP top STRUCTURAL
+    MUST ( automountKey $ automountInformation )
+    MAY description )
+'''
+
+# `groupOfMembers` (RFC 2307bis companion class): a group that permits zero
+# members, used as the structural class for our posix groups. Not shipped in
+# any stock Ubuntu schema; OID is the canonical one from the rfc2307bis
+# draft ecosystem.
+_GOM_SCHEMA = '''\
+objectclass ( 1.3.6.1.4.1.5322.13.1.1
+    NAME 'groupOfMembers'
+    DESC 'A group with an optional member list'
+    SUP top STRUCTURAL
+    MUST cn
+    MAY ( member $ businessCategory $ seeAlso $ owner $ ou $ o $
+          description ) )
+'''
+
 
 def _slapd_config(data_dir, schema_dir, lpk_schema_path) -> str:
     """Build a slapd.conf string. Uses the older config-file style (vs.
     cn=config) so the fixture is straightforward to write inline."""
-    # Hash the admin password — slapd accepts the {SSHA} or {PLAIN} form.
-    # Passing it plain and prefixing with {CLEARTEXT} works on Ubuntu's slapd.
+    # rootpw is plain (no scheme prefix): slapd treats an unschemed value
+    # as cleartext, while a {CLEARTEXT} prefix fails to verify on current
+    # Ubuntu builds (bind gets Invalid credentials).
     return f'''\
 include {schema_dir}/core.schema
 include {schema_dir}/cosine.schema
 include {schema_dir}/inetorgperson.schema
 include {schema_dir}/nis.schema
 include {lpk_schema_path}
-
-# Automount schema (defines automount, automountMap objectClasses) is part
-# of OpenLDAP's nis.schema — already included.
-
-# Ubuntu's slapd ships backends as loadable modules.
-modulepath /usr/lib/ldap
-moduleload back_mdb.so
+include {schema_dir}/autofs.schema
+include {schema_dir}/gom.schema
 
 pidfile  {data_dir}/slapd.pid
 argsfile {data_dir}/slapd.args
 
-database   mdb
-maxsize    1073741824
+# ldif backend (built into slapd, plain files, no LMDB): Ubuntu's slapd
+# apparmor profile grants rw but NOT file_lock (k) on /var/tmp/**, so the
+# mdb backend fails mdb_db_open with EACCES on confined hosts. The ldif
+# backend takes no locks and is plenty for an ephemeral test directory.
+database   ldif
 suffix     "{SLAPD_BASE_DN}"
 rootdn     "{SLAPD_ADMIN_DN}"
-rootpw     {{CLEARTEXT}}{SLAPD_ADMIN_PASSWORD}
+rootpw     {SLAPD_ADMIN_PASSWORD}
 directory  {data_dir}
 
 # Permissive ACL — this is a test instance.
@@ -462,7 +516,13 @@ def start_slapd():
     Uses /var/tmp instead of /tmp because Ubuntu's slapd apparmor profile
     only allows /etc/ldap, /var/lib/ldap, and /var/tmp.
     '''
-    if shutil.which('slapd') is None:
+    # slapd installs to sbin, which is typically not on a non-root PATH —
+    # check there too so the integration suite doesn't silently skip on
+    # hosts that have it.
+    slapd_bin = shutil.which('slapd') or shutil.which(
+        'slapd', path='/usr/sbin:/usr/local/sbin:/sbin',
+    )
+    if slapd_bin is None:
         pytest.skip('slapd not available; install with apt install slapd')
 
     import tempfile
@@ -486,8 +546,24 @@ def start_slapd():
             pytest.skip(f'missing slapd schema {src}; install slapd properly')
         _convert_schema_ldif_to_legacy(src, schema_dir / f'{name}.schema')
 
+    # Stock nis.schema is rfc2307: posixGroup is STRUCTURAL there, which
+    # cannot combine with our structural groupOfMembers. Production
+    # directories follow rfc2307bis, where posixGroup is AUXILIARY — patch
+    # the distro definition to match.
+    nis_path = schema_dir / 'nis.schema'
+    nis_text = nis_path.read_text()
+    pg_start = nis_text.index("NAME 'posixGroup'")
+    pg_end = nis_text.index(')', nis_text.index('MAY', pg_start))
+    nis_path.write_text(
+        nis_text[:pg_start]
+        + nis_text[pg_start:pg_end].replace('STRUCTURAL', 'AUXILIARY')
+        + nis_text[pg_end:]
+    )
+
     lpk_schema_path = schema_dir / 'lpk.schema'
     lpk_schema_path.write_text(_LPK_SCHEMA)
+    (schema_dir / 'autofs.schema').write_text(_AUTOFS_SCHEMA)
+    (schema_dir / 'gom.schema').write_text(_GOM_SCHEMA)
 
     conf_path = base_dir / 'slapd.conf'
     conf_path.write_text(_slapd_config(data_dir, schema_dir, lpk_schema_path))
@@ -499,7 +575,7 @@ def start_slapd():
     # files we created under /var/tmp/cheeto-slapd-*).
     proc = subprocess.Popen(
         [
-            '/usr/sbin/slapd',
+            slapd_bin,
             '-h', f'ldap://127.0.0.1:{SLAPD_PORT}/',
             '-f', str(conf_path),
             '-d', '256',  # config processing only — quiet but reports errors
@@ -532,18 +608,15 @@ def start_slapd():
         proc.terminate()
         proc.wait()
         log_text = log_path.read_text() if log_path.exists() else '(no log)'
-        # Common dev-box failure: Ubuntu's apparmor profile for slapd
-        # denies file_lock on /var/tmp/**, which LMDB needs. Skip rather
-        # than fail when we recognize that signature so the rest of the
-        # suite still runs on locked-down hosts.
-        if 'Permission denied' in log_text and (
-            'lock.mdb' in log_text or 'mdb_db_open' in log_text
-        ):
+        # Apparmor-confined hosts can still deny the backend's file access
+        # under /var/tmp; skip rather than fail so the rest of the suite
+        # runs on locked-down hosts.
+        if 'Permission denied' in log_text:
             shutil.rmtree(base_dir, ignore_errors=True)
             pytest.skip(
-                'slapd cannot open LMDB under /var/tmp; likely apparmor '
-                'on the host. Run integration tests in a container or '
-                'disable the slapd apparmor profile.'
+                'slapd cannot open its database under /var/tmp; likely '
+                'apparmor on the host. Run integration tests in a '
+                'container or disable the slapd apparmor profile.'
             )
         raise RuntimeError(f'slapd did not start in time. Log:\n{log_text}')
 

--- a/cheeto/tests/test_ldap_async.py
+++ b/cheeto/tests/test_ldap_async.py
@@ -9,6 +9,7 @@ Skips automatically when `slapd` isn't available on the host.
 
 from __future__ import annotations
 
+import bonsai
 import pytest
 import pytest_asyncio
 
@@ -21,6 +22,31 @@ from ..ldap_async import (
 
 
 SITENAME = 'test-cluster'
+
+
+async def _raw_attr(config, dn: str, attr: str) -> list[str] | None:
+    """Fetch one attribute of `dn` with a fresh admin bind, bypassing the
+    manager's record mapping — the raw server truth, independent of what
+    entry_to_user projects. Returns None when the attribute (or entry) is
+    absent."""
+    client = bonsai.LDAPClient(config.servers[0])
+    client.set_credentials(
+        'SIMPLE', user=config.login_dn, password=config.password,
+    )
+    async with client.connect(is_async=True) as conn:
+        results = await conn.search(
+            dn, bonsai.LDAPSearchScope.BASE, '(objectClass=*)',
+            attrlist=[attr],
+        )
+    if not results:
+        return None
+    values = results[0].get(attr)
+    if not values:
+        return None
+    return [
+        v.decode() if isinstance(v, (bytes, bytearray)) else str(v)
+        for v in values
+    ]
 
 
 @pytest_asyncio.fixture(loop_scope='session')
@@ -81,8 +107,13 @@ class TestEnsureSiteTree:
 
     async def test_creates_full_tree(self, manager):
         result = await manager.ensure_site_tree()
-        # All 6 DNs created plus the 2 automount keys = 8.
-        assert all(v == 'created' for v in result.values()), result
+        # ou=users is seeded by the slapd fixture itself, so it reports
+        # already_exists; every per-site entry must be freshly created.
+        assert result[manager.user_ou_dn()] == 'already_exists'
+        assert all(
+            v == 'created' for dn, v in result.items()
+            if dn != manager.user_ou_dn()
+        ), result
         # Verify each is now present.
         for dn in result.keys():
             assert await manager.dn_exists(dn)
@@ -102,7 +133,7 @@ class TestUserCRUD:
     async def test_add_get_delete_user(self, manager, site):
         record = LDAPUserRecord(
             username='alice', email='alice@example.test',
-            uid=10001, gid=10001, fullname='Alice',
+            uid=10001, gid=10001, fullname='Alice', surname='Alice',
             home_directory='/home/alice', shell='/usr/bin/bash',
         )
         await manager.add_user(record)
@@ -123,7 +154,7 @@ class TestUserCRUD:
     async def test_update_user(self, manager, site):
         record = LDAPUserRecord(
             username='bob', email='bob@example.test',
-            uid=10002, gid=10002, fullname='Bob',
+            uid=10002, gid=10002, fullname='Bob', surname='Bob',
             home_directory='/home/bob', shell='/usr/bin/bash',
         )
         await manager.add_user(record)
@@ -135,11 +166,90 @@ class TestUserCRUD:
     async def test_update_nonexistent_user_raises(self, manager, site):
         ghost = LDAPUserRecord(
             username='ghost', email='nope@x',
-            uid=99999, gid=99999, fullname='Ghost',
+            uid=99999, gid=99999, fullname='Ghost', surname='Ghost',
             home_directory='/home/ghost', shell='/usr/bin/bash',
         )
         with pytest.raises(LDAPNotFound):
             await manager.update_user(ghost)
+
+    async def test_user_password_written_updated_cleared(
+        self, manager, site, slapd_ldap_config,
+    ):
+        record = LDAPUserRecord(
+            username='pwrt', email='pwrt@x.test',
+            uid=10010, gid=10010, fullname='PW RT', surname='RT',
+            home_directory='/home/pwrt', shell='/usr/bin/bash',
+            password='$y$j9T$firstsalt$firsthash',
+        )
+        await manager.add_user(record)
+        dn = manager.user_dn('pwrt')
+        assert await _raw_attr(slapd_ldap_config, dn, 'userPassword') == [
+            '{CRYPT}$y$j9T$firstsalt$firsthash',
+        ]
+        # get_user round-trips the wire form for presence reporting.
+        fetched = await manager.get_user('pwrt')
+        assert fetched.password == '{CRYPT}$y$j9T$firstsalt$firsthash'
+
+        record.password = '$y$j9T$secondsalt$secondhash'
+        await manager.update_user(record)
+        assert await _raw_attr(slapd_ldap_config, dn, 'userPassword') == [
+            '{CRYPT}$y$j9T$secondsalt$secondhash',
+        ]
+
+        # Clearing the password in beanie must remove the stale hash.
+        record.password = None
+        await manager.update_user(record)
+        assert await _raw_attr(slapd_ldap_config, dn, 'userPassword') is None
+        assert (await manager.get_user('pwrt')).password is None
+
+    async def test_user_password_bind_end_to_end(
+        self, manager, site, slapd_ldap_config,
+    ):
+        # Full regression pin for the {CRYPT} prefix: hash a plaintext with
+        # the real production hasher, sync it, then simple-bind as the user.
+        # Requires the host's crypt(3)/libxcrypt to support yescrypt
+        # (standard on Ubuntu 22.04+).
+        from ..operations.user import _hash_password
+
+        plaintext = 'correct-horse-battery-staple'
+        record = LDAPUserRecord(
+            username='pwbind', email='pwbind@x.test',
+            uid=10011, gid=10011, fullname='PW Bind', surname='Bind',
+            home_directory='/home/pwbind', shell='/usr/bin/bash',
+            password=_hash_password(plaintext),
+        )
+        await manager.add_user(record)
+        user_dn = manager.user_dn('pwbind')
+
+        good = bonsai.LDAPClient(slapd_ldap_config.servers[0])
+        good.set_credentials('SIMPLE', user=user_dn, password=plaintext)
+        async with good.connect(is_async=True) as conn:
+            assert 'pwbind' in await conn.whoami()
+
+        bad = bonsai.LDAPClient(slapd_ldap_config.servers[0])
+        bad.set_credentials('SIMPLE', user=user_dn, password='wrong-password')
+        with pytest.raises(bonsai.AuthenticationError):
+            async with bad.connect(is_async=True):
+                pass
+
+    async def test_update_clears_stale_ssh_keys(
+        self, manager, site, slapd_ldap_config,
+    ):
+        record = LDAPUserRecord(
+            username='keyclr', email='keyclr@x.test',
+            uid=10012, gid=10012, fullname='Key Clear', surname='Clear',
+            home_directory='/home/keyclr', shell='/usr/bin/bash',
+            ssh_keys=['ssh-ed25519 AAA keyclr@x'],
+        )
+        await manager.add_user(record)
+        dn = manager.user_dn('keyclr')
+        assert await _raw_attr(slapd_ldap_config, dn, 'sshPublicKey') == [
+            'ssh-ed25519 AAA keyclr@x',
+        ]
+
+        record.ssh_keys = []
+        await manager.update_user(record)
+        assert await _raw_attr(slapd_ldap_config, dn, 'sshPublicKey') is None
 
 
 class TestGroupCRUD:
@@ -166,7 +276,7 @@ class TestGroupCRUD:
         for n, uid in [('carol', 10003), ('dave', 10004), ('eve', 10005)]:
             await manager.add_user(LDAPUserRecord(
                 username=n, email=f'{n}@x.test',
-                uid=uid, gid=uid, fullname=n.title(),
+                uid=uid, gid=uid, fullname=n.title(), surname=n.title(),
                 home_directory=f'/home/{n}', shell='/usr/bin/bash',
             ))
         await manager.add_group(LDAPGroupRecord(
@@ -181,7 +291,7 @@ class TestGroupCRUD:
     async def test_list_user_memberships(self, manager, site):
         await manager.add_user(LDAPUserRecord(
             username='frank', email='frank@x.test',
-            uid=10006, gid=10006, fullname='Frank',
+            uid=10006, gid=10006, fullname='Frank', surname='Frank',
             home_directory='/home/frank', shell='/usr/bin/bash',
         ))
         await manager.add_group(LDAPGroupRecord(

--- a/cheeto/tests/test_ldap_mapping.py
+++ b/cheeto/tests/test_ldap_mapping.py
@@ -150,6 +150,25 @@ class TestEntryToUser:
         record = entry_to_user(entry)
         assert record.fullname == 'Carol Lastname'
 
+    def test_reads_password_str(self):
+        entry = _mock_entry({
+            'uid': ['pw'],
+            'userPassword': ['{CRYPT}$y$j9T$salt$hash'],
+        })
+        assert entry_to_user(entry).password == '{CRYPT}$y$j9T$salt$hash'
+
+    def test_reads_password_bytes(self):
+        # userPassword is Octet String syntax; bonsai may return bytes.
+        entry = _mock_entry({
+            'uid': ['pw'],
+            'userPassword': [b'{CRYPT}$y$j9T$salt$hash'],
+        })
+        assert entry_to_user(entry).password == '{CRYPT}$y$j9T$salt$hash'
+
+    def test_password_absent_is_none(self):
+        entry = _mock_entry({'uid': ['pw']})
+        assert entry_to_user(entry).password is None
+
 
 class TestUserToEntryAttrs:
 
@@ -170,7 +189,8 @@ class TestUserToEntryAttrs:
         assert attrs['mail'] == ['carol@example.test']
         assert attrs['uidNumber'] == [10003]
         assert attrs['sshPublicKey'] == ['ssh-ed25519 AAA']
-        assert attrs['userPassword'] == ['*']
+        # Schemeless values get the RFC-2307 {CRYPT} prefix on the wire.
+        assert attrs['userPassword'] == ['{CRYPT}*']
 
     def test_skips_empty_optionals(self):
         record = LDAPUserRecord(
@@ -195,6 +215,23 @@ class TestUserToEntryAttrs:
         )
         attrs = user_to_entry_attrs(record)
         assert attrs['sn'] == ['Smith']
+
+    def test_password_crypt_prefix(self):
+        # Bare yescrypt MCF hashes (what CreateUser/SetUserPassword store)
+        # get the {CRYPT} scheme prefix slapd needs to verify them as
+        # crypt(3) hashes; values already carrying a scheme pass through.
+        record = LDAPUserRecord(
+            username='pw', email='pw@x.test',
+            uid=10006, gid=10006, fullname='PW',
+            home_directory='/home/pw', shell='/usr/bin/bash',
+            password='$y$j9T$abcdefsalt$abcdefhash',
+        )
+        attrs = user_to_entry_attrs(record)
+        assert attrs['userPassword'] == ['{CRYPT}$y$j9T$abcdefsalt$abcdefhash']
+
+        record.password = '{SSHA}already-schemed'
+        attrs = user_to_entry_attrs(record)
+        assert attrs['userPassword'] == ['{SSHA}already-schemed']
 
 
 class TestShadowExpireRoundTrip:


### PR DESCRIPTION
Restores working password projection to LDAP (v1 parity) and makes it observable. Root cause of "passwords not in LDAP": v2 dropped the RFC-2307 {CRYPT} scheme prefix v1 prepended to yescrypt hashes (added in 12738d2, lost with cheeto/database/ldap.py in the 1f87022 cutover) — slapd treats a bare $y$... value as cleartext, so binds always fail. objectClasses were NOT the problem (inetOrgPerson/posixAccount/shadowAccount all permit userPassword), nor was the migration (it copies the hash).