### PR TITLE
Add --start-at to `user new class` for extending a roster

### DIFF
--- a/cheeto/cmds/ng/user.py
+++ b/cheeto/cmds/ng/user.py
@@ -446,8 +446,9 @@ async def user_new_class(args: Namespace):
     try:
         results = await CreateClassUsers.run(
             args.db, args.author,
-            prefix=args.prefix, count=args.count, email=args.email,
-            expires_at=args.expires_at, access=args.access,
+            prefix=args.prefix, count=args.count, start_at=args.start_at,
+            email=args.email, expires_at=args.expires_at,
+            access=args.access,
             site_name=args.site, group_name=args.group,
         )
     except ValueError as e:
@@ -499,6 +500,10 @@ def _(parser: ArgParser):
                              'width of N')
     parser.add_argument('--count', '-n', type=int, required=True,
                         help='Number of class accounts to create')
+    parser.add_argument('--start-at', type=int, default=1,
+                        help='Number the first account PREFIX-<START-AT> '
+                             'instead of PREFIX-1 (for adding users to an '
+                             'existing class)')
     parser.add_argument('--expires-at', type=expirable_value, required=True,
                         metavar='WHEN',
                         help="Account lifetime: ISO 8601 ('2027-01-15') or "

--- a/cheeto/operations/user.py
+++ b/cheeto/operations/user.py
@@ -282,9 +282,11 @@ DEFAULT_CLASS_ACCESS = ('login-ssh', 'slurm')
 
 
 class CreateClassUsers(Operation):
-    """Batch-create a class roster: `count` users named
-    `{prefix}-{i}` (1-indexed, zero-padded to len(str(count)) digits), each
-    type='class' with a generated password and a mandatory expiration.
+    """Batch-create a class roster: `count` users named `{prefix}-{i}` for
+    i in start_at..start_at+count-1 (default start 1), zero-padded to the
+    width of the largest generated number, each type='class' with a
+    generated password and a mandatory expiration. Pass `start_at` to
+    append additional users to an existing roster.
 
     Runs as one transaction: the uid block is allocated once up front and
     all user/personal-group name collisions are pre-checked in single
@@ -315,12 +317,15 @@ class CreateClassUsers(Operation):
         email: str,
         expires_at: datetime,
         site_name: str,
+        start_at: int = 1,
         access: list[str] | None = None,
         group_name: str | None = None,
     ) -> None:
         super().__init__(client, author)
         if count < 1:
             raise ValueError('count must be >= 1')
+        if start_at < 1:
+            raise ValueError('start_at must be >= 1')
         if not isinstance(expires_at, datetime):
             raise ValueError(
                 'class accounts require an expiration (expires_at)'
@@ -330,9 +335,10 @@ class CreateClassUsers(Operation):
                 f'Invalid prefix {prefix!r}: must start with a lowercase '
                 'letter and contain only [a-z0-9-]'
             )
-        width = len(str(count))
+        last = start_at + count - 1
+        width = len(str(last))
         self.names = [
-            f'{prefix}-{i:0{width}d}' for i in range(1, count + 1)
+            f'{prefix}-{i:0{width}d}' for i in range(start_at, last + 1)
         ]
         if len(prefix) + 1 + width > 32:
             raise ValueError(
@@ -341,6 +347,7 @@ class CreateClassUsers(Operation):
             )
         self.prefix = prefix
         self.count = count
+        self.start_at = start_at
         self.email = email
         self.expires_at = expires_at
         self.access = list(access) if access else list(DEFAULT_CLASS_ACCESS)
@@ -413,6 +420,7 @@ class CreateClassUsers(Operation):
         return {
             'prefix': self.prefix,
             'count': self.count,
+            'start_at': self.start_at,
             'usernames': self.names,
             'base_uid': self._base_uid,
             'email': self.email,

--- a/cheeto/tests/test_beanie.py
+++ b/cheeto/tests/test_beanie.py
@@ -1134,6 +1134,67 @@ class TestCreateClassUsersOp:
         assert names[8] == 'pad-09'
         assert names[9] == 'pad-10'
 
+    async def test_start_at_extends_existing_class(self, beanie_client):
+        from cheeto.constants import MIN_CLASS_ID
+
+        await self._seed_class_site(beanie_client)
+        await CreateClassUsers.run(
+            beanie_client, None,
+            prefix='ext', count=3, email='ext@test.com',
+            expires_at=CLASS_EXPIRY, site_name='clsite',
+        )
+        results = await CreateClassUsers.run(
+            beanie_client, None,
+            prefix='ext', count=2, start_at=4, email='ext@test.com',
+            expires_at=CLASS_EXPIRY, site_name='clsite',
+        )
+        assert [u.name for u, _ in results] == ['ext-4', 'ext-5']
+        assert [u.uid for u, _ in results] == [
+            MIN_CLASS_ID + 3, MIN_CLASS_ID + 4,
+        ]
+        hists = await History.find(
+            History.op == 'create_class_users',
+        ).sort('+timestamp').to_list()
+        assert len(hists) == 2
+        assert hists[0].changes['start_at'] == 1
+        assert hists[1].changes['start_at'] == 4
+
+    async def test_start_at_padding_crosses_boundary(self, beanie_client):
+        # Width comes from the largest generated number, not count.
+        await self._seed_class_site(beanie_client)
+        results = await CreateClassUsers.run(
+            beanie_client, None,
+            prefix='xb', count=3, start_at=9, email='xb@test.com',
+            expires_at=CLASS_EXPIRY, site_name='clsite',
+        )
+        assert [u.name for u, _ in results] == ['xb-09', 'xb-10', 'xb-11']
+
+    async def test_start_at_overlap_rolls_back(self, beanie_client):
+        await self._seed_class_site(beanie_client)
+        await CreateClassUsers.run(
+            beanie_client, None,
+            prefix='ov', count=3, email='ov@test.com',
+            expires_at=CLASS_EXPIRY, site_name='clsite',
+        )
+        with pytest.raises(ValueError, match=r'User\(s\) already exist: ov-3'):
+            await CreateClassUsers.run(
+                beanie_client, None,
+                prefix='ov', count=2, start_at=3, email='ov@test.com',
+                expires_at=CLASS_EXPIRY, site_name='clsite',
+            )
+        assert await User.find_one(User.name == 'ov-4') is None
+
+    async def test_start_at_zero_rejected(self, beanie_client):
+        with pytest.raises(ValueError, match='start_at must be'):
+            await CreateClassUsers.run(
+                beanie_client, None,
+                prefix='sz', count=2, start_at=0, email='sz@test.com',
+                expires_at=CLASS_EXPIRY, site_name='anysite',
+            )
+        assert await User.find_all().count() == 0
+        assert await History.find_one(
+            History.op == 'create_class_users') is None
+
     async def test_uid_blocks_are_sequential(self, beanie_client):
         from cheeto.constants import MIN_CLASS_ID
 


### PR DESCRIPTION
CreateClassUsers gains start_at (default 1): accounts are numbered start_at..start_at+count-1, zero-padded to the width of the largest generated number — identical to the old len(str(count)) rule when starting at 1, and consistent with the original batch when extending within the same power of ten (-01..-20 + `--start-at 21 -n 5` -> -21..-25). start_at is validated >= 1 and recorded in History.

The existing batch safety nets cover extension for free: an overlapping start_at fails the up-front name pre-check with the clashing names and rolls the transaction back, and uid allocation continues from the class-range max so the second batch's uids follow the first.

Tests: extension continuity (names, uids, per-batch History start_at), padding across a power-of-ten boundary, overlap rollback, start_at=0 rejection.

Full suite: 536 passed, 1 skipped.