### PR TITLE
Fix stale expires_at across status transitions; add `iam restorable`

### DIFF
--- a/cheeto/cmds/ng/iam.py
+++ b/cheeto/cmds/ng/iam.py
@@ -24,7 +24,7 @@ from ...operations import (
     SyncUserIAM,
 )
 from ...operations.iam import maybe_notify_offboarding, maybe_notify_restored
-from ...queries import resolve_status_name
+from ...queries import find_restorable_users, resolve_status_name
 from ...yaml import print_yaml
 from ._args import user_args, yaml_args
 
@@ -308,6 +308,82 @@ def _(parser: ArgParser):
     parser.add_argument('--notify', action='store_true', default=False,
                         help='Email each user when their account is '
                              'deactivated')
+
+
+# ---------------------------------------------------------------------------
+# `ng iam restorable` — inactive/disabled accounts whose IAM record is back
+# ---------------------------------------------------------------------------
+
+
+@yaml_args.apply()
+@commands.register('ng', 'iam', 'restorable',
+                   help='List users whose IAM record is valid again but '
+                        'whose status was never restored (e.g. returned '
+                        'after the offboarding window)')
+async def iam_restorable_cmd(args: Namespace):
+    console = Console()
+    users = await find_restorable_users(status_names=tuple(args.status))
+
+    if args.yaml:
+        print_yaml([
+            {
+                'name': u.name,
+                'email': u.email,
+                'type': u.type,
+                'status': await resolve_status_name(u.status),
+                'iam_id': (
+                    u.iam.person.iam_id
+                    if u.iam and u.iam.person else None
+                ),
+                'last_seen_at': u.iam.last_seen_at if u.iam else None,
+                'iam_synced_at': u.iam.iam_synced_at if u.iam else None,
+                'expires_at': u.expires_at,
+            }
+            for u in users
+        ])
+        return 0
+
+    if not users:
+        console.print('[dim](no restorable users)[/]')
+        return
+
+    table = Table(box=None, pad_edge=False, padding=(0, 1))
+    table.add_column('user', style='bold')
+    table.add_column('email')
+    table.add_column('type', style='dim')
+    table.add_column('status', style='yellow')
+    table.add_column('iam_id')
+    table.add_column('last_seen_at', style='green')
+    table.add_column('iam_synced_at', style='dim')
+    table.add_column('expired_at')
+    for u in users:
+        iam = u.iam
+        table.add_row(
+            u.name, u.email, u.type,
+            await resolve_status_name(u.status) or '—',
+            str(iam.person.iam_id) if iam and iam.person else '—',
+            str(iam.last_seen_at) if iam and iam.last_seen_at else '—',
+            str(iam.iam_synced_at) if iam and iam.iam_synced_at else '—',
+            str(u.expires_at) if u.expires_at else '—',
+        )
+    console.print(Panel(
+        table,
+        title=f'[bold]Restorable users[/] ({len(users)})',
+        border_style='cyan', expand=False,
+    ))
+    console.print(
+        '[dim]Reactivate with: '
+        'cheeto ng user status -u <name> --status active --reason ...[/]'
+    )
+
+
+@iam_restorable_cmd.args()
+def _(parser: ArgParser):
+    parser.add_argument('--status', nargs='+',
+                        choices=('inactive', 'disabled', 'offboarding'),
+                        default=['inactive'],
+                        help='Which cheeto statuses to scan '
+                             '(default: inactive)')
 
 
 # ---------------------------------------------------------------------------

--- a/cheeto/operations/iam.py
+++ b/cheeto/operations/iam.py
@@ -4,7 +4,10 @@ Three ops live here:
 
   - `SyncUserIAM` — single-user sync. Implements the full state machine:
       hit / hit_restored / miss_first / miss_within_grace / miss_offboarding /
-      miss_already_expiring / miss_not_active.
+      miss_already_expiring / miss_not_active. `hit_restored` fires for ANY
+      hit on an 'offboarding' user (even past its expiry — the reaper may not
+      have swept yet); operator-set inactive/disabled are never resurrected
+      (surface those with `ng iam restorable`).
   - `SyncAllUsersIAM` — driver that loops `SyncUserIAM` over candidate users
     (filtered to `IAM_SYNCABLE_USER_TYPES` so administrative `system`/`class`/
     `shared` accounts are never touched).
@@ -257,16 +260,15 @@ class SyncUserIAM(Operation):
         # the existing one wholesale (associations, user_types, etc.).
         user.iam = build_ucdiam_info(bundle, now=self.now)
 
-        # Restore from offboarding only if status is still 'offboarding' AND
-        # expires_at hasn't passed. Operator-set statuses (inactive, disabled)
-        # are NOT auto-resurrected.
+        # Restore any user still in 'offboarding' — that status is owned by
+        # this machinery, so an IAM hit always reverses it, INCLUDING when
+        # expires_at has already lapsed but the reaper hasn't swept yet
+        # (otherwise that scheduling race deactivates a returning person).
+        # Operator-set statuses (inactive, disabled) are NOT auto-resurrected;
+        # `ng iam restorable` surfaces those for manual review.
         restored = False
         current_status = await resolve_status_name(user.status)
-        if (
-            user.expires_at is not None
-            and user.expires_at > self.now
-            and current_status == 'offboarding'
-        ):
+        if current_status == 'offboarding':
             user.expires_at = None
             user.status = await find_status_group('active')
             restored = True
@@ -492,6 +494,11 @@ class SyncAllUsersIAM(Operation):
 class ReapOffboardedUsers(Operation):
     """Find users in 'offboarding' status whose expires_at has passed and
     flip them to 'inactive'. No IAM I/O.
+
+    The past `expires_at` is intentionally KEPT on the reaped user: it
+    records the deactivation date and keeps projecting a past LDAP
+    shadowExpire as defense-in-depth on the disabled account. Reactivation
+    paths (SetUserStatus -> active, IAM hit_restored) clear it.
 
     One History entry is written for the operation as a whole (with a list
     of the affected users in describe()). This is intentionally a single

--- a/cheeto/operations/user.py
+++ b/cheeto/operations/user.py
@@ -498,11 +498,15 @@ class SetUserStatus(Operation):
             raise ValueError(f'User {self.name} does not exist')
 
         if self.site is None:
-            # Clear the pending offboarding expiry when reactivating, so the
-            # next IAM sync doesn't immediately re-offboard the user.
+            # Reactivation from ANY non-active status drops the expiry: the
+            # offboarding machinery owns expires_at through the offboarding ->
+            # reaped(inactive) lifecycle, and a stale (often past) value would
+            # otherwise keep projecting to LDAP shadowExpire and block login.
+            # active -> active is untouched so a deliberately-set expiry on an
+            # active account (class users) survives a redundant re-set.
             if (
                 self.status == 'active'
-                and await resolve_status_name(user.status) == 'offboarding'
+                and await resolve_status_name(user.status) != 'active'
             ):
                 user.expires_at = None
             user.status = await _resolve_status_link(self.status)
@@ -525,9 +529,12 @@ class SetUserStatus(Operation):
                 usi.status = None
                 usi.expires_at = None
             else:
+                # Mirror the global rule: an explicit active override coming
+                # from a non-active per-site status drops the per-site expiry.
                 if (
                     self.status == 'active'
-                    and await resolve_status_name(usi.status) == 'offboarding'
+                    and await resolve_status_name(usi.status)
+                    not in (None, 'active')
                 ):
                     usi.expires_at = None
                 status_link = await _resolve_status_link(self.status)

--- a/cheeto/queries/__init__.py
+++ b/cheeto/queries/__init__.py
@@ -51,6 +51,7 @@ from .user import (
     find_user_by_name,
     find_user_by_uid,
     find_users,
+    find_restorable_users,
     list_user_ssh_keys,
     root_authorized_keys_text,
     root_key_blocks,

--- a/cheeto/queries/user.py
+++ b/cheeto/queries/user.py
@@ -292,6 +292,32 @@ async def find_users(
     ).sort('+name').to_list()
 
 
+async def find_restorable_users(
+    status_names: tuple[str, ...] = ('inactive',),
+) -> list[User]:
+    """Users whose cheeto status says they are gone but whose latest IAM
+    snapshot is 'present' — people who regained UC Davis affiliation after
+    the offboarding window closed, so the IAM sync's auto-restore (which
+    only fires for 'offboarding') never reactivated them. Candidates for a
+    manual `user status --status active`.
+
+    Relies on the snapshot staying fresh: `SyncAllUsersIAM` re-syncs users
+    of syncable type regardless of status, flipping `iam.iam_status` back
+    to 'present' on a hit while leaving the status untouched.
+    """
+    sg_ids = []
+    for name in status_names:
+        sg = await StatusGroup.find_one(StatusGroup.status_name == name)
+        if sg is not None:
+            sg_ids.append(sg.id)
+    if not sg_ids:
+        return []
+    return await User.find(
+        In(User.status.id, sg_ids),
+        User.iam.iam_status == 'present',
+    ).sort('+name').to_list()
+
+
 async def find_redundant_site_statuses() -> list[tuple[str, str, str]]:
     """Per-site status overrides that merely duplicate the user's global
     status (`usi.status` and `user.status` point at the same StatusGroup).

--- a/cheeto/tests/test_beanie.py
+++ b/cheeto/tests/test_beanie.py
@@ -1371,6 +1371,73 @@ class TestUserMutationOps:
         assert usi.status is None
         assert usi.expires_at is None
 
+    async def _set_status_with_expiry(self, beanie_client, user, status):
+        from datetime import datetime as _dt
+        await SetUserStatus.run(
+            beanie_client, None,
+            name='mutuser', status=status, reason='seed',
+        )
+        fetched = await User.find_one(User.name == 'mutuser')
+        fetched.expires_at = _dt(2020, 6, 1)
+        await fetched.save()
+
+    @pytest.mark.parametrize('prior', ['inactive', 'disabled', 'offboarding'])
+    async def test_reactivation_clears_expiry(
+        self, beanie_client, user, prior,
+    ):
+        # Reactivating from ANY non-active status must drop the stale
+        # expiry, or it keeps projecting a past LDAP shadowExpire that
+        # blocks login (the reaped-then-reactivated regression).
+        await self._set_status_with_expiry(beanie_client, user, prior)
+        await SetUserStatus.run(
+            beanie_client, None,
+            name='mutuser', status='active', reason='back',
+        )
+        fetched = await User.find_one(
+            User.name == 'mutuser', fetch_links=True, nesting_depth=1,
+        )
+        assert fetched.status.status_name == 'active'
+        assert fetched.expires_at is None
+
+    async def test_active_to_active_keeps_expiry(self, beanie_client, user):
+        # A deliberately-set expiry on an already-active account (class
+        # users) survives a redundant re-set to active.
+        from datetime import datetime as _dt
+        fetched = await User.find_one(User.name == 'mutuser')
+        fetched.expires_at = _dt(2030, 6, 1)
+        await fetched.save()
+        await SetUserStatus.run(
+            beanie_client, None,
+            name='mutuser', status='active', reason='noop',
+        )
+        fetched = await User.find_one(User.name == 'mutuser')
+        assert fetched.expires_at == _dt(2030, 6, 1)
+
+    async def test_site_reactivation_clears_site_expiry(
+        self, beanie_client, user,
+    ):
+        # Per-site mirror: explicit active override from a non-active
+        # per-site status drops usi.expires_at; global expiry untouched.
+        from datetime import datetime as _dt
+        site = await self._site_with_usi(user, usi_status='disabled')
+        usi = await UserSiteInfo.find_one(UserSiteInfo.user.id == user.id)
+        usi.expires_at = _dt(2020, 6, 1)
+        await usi.save()
+        fetched = await User.find_one(User.name == 'mutuser')
+        fetched.expires_at = _dt(2030, 6, 1)
+        await fetched.save()
+
+        await SetUserStatus.run(
+            beanie_client, None,
+            name='mutuser', status='active', reason='r', site='mut_site',
+        )
+        usi = await UserSiteInfo.find_one(
+            UserSiteInfo.user.id == user.id, UserSiteInfo.site.id == site.id,
+        )
+        assert usi.expires_at is None
+        fetched = await User.find_one(User.name == 'mutuser')
+        assert fetched.expires_at == _dt(2030, 6, 1)
+
     async def test_set_user_status_reset_requires_site(
         self, beanie_client, user,
     ):

--- a/cheeto/tests/test_iam_sync.py
+++ b/cheeto/tests/test_iam_sync.py
@@ -448,6 +448,42 @@ class TestSyncUserIAM:
         assert fetched.iam.first_missing_at is None
         assert fetched.iam.last_seen_at == now
 
+    async def test_hit_restored_from_offboarding_lapsed_expiry(
+        self, beanie_client, make_user,
+    ):
+        # The reaper may not have swept yet when a returning user's hit
+        # arrives: expires_at already lapsed but status still 'offboarding'.
+        # The hit must still restore — otherwise the next reap deactivates
+        # an IAM-present person (iam_sync/reap scheduling race).
+        from ..models.user import UCDIAMInfo
+        now = datetime(2026, 5, 1)
+        lapsed_expiry = now - timedelta(days=2)
+        user = await make_user(
+            status='offboarding',
+            expires_at=lapsed_expiry,
+            iam=UCDIAMInfo(
+                iam_status='missing',
+                person=UCDIAMPerson(iam_id=1000000001, mothra_id=1000001),
+                first_missing_at=now - timedelta(days=40),
+            ),
+        )
+        handler = make_iam_handler(
+            person=[PERSON_JANE], associations=[], division={},
+        )
+        async with make_iam_api(handler) as api:
+            result = await SyncUserIAM.run(
+                beanie_client, None,
+                username=user.name, iam_api=api,
+                grace_days=14, expiry_offset_days=30, now=now,
+            )
+        assert result.outcome == 'hit_restored'
+
+        fetched = await User.find_one(
+            User.name == user.name, fetch_links=True, nesting_depth=1,
+        )
+        assert fetched.status.status_name == 'active'
+        assert fetched.expires_at is None
+
     async def test_hit_does_not_resurrect_inactive_user(self, beanie_client, make_user):
         from ..models.user import UCDIAMInfo
         now = datetime(2026, 5, 1)
@@ -951,6 +987,10 @@ class TestReapOffboardedUsers:
         assert future.status.status_name == 'offboarding'
         assert no_expiry.status.status_name == 'offboarding'
         assert already.status.status_name == 'inactive'
+        # The past expiry is intentionally KEPT on the reaped user: it
+        # records the deactivation date and keeps shadowExpire blocking the
+        # inactive account. Reactivation paths clear it.
+        assert past.expires_at == now - timedelta(days=1)
 
     async def test_empty_when_nothing_due(self, beanie_client):
         now = datetime(2026, 5, 1)
@@ -1367,3 +1407,61 @@ class TestSendUserEmail:
         assert hist is not None
         assert hist.changes['sent'] is False
         assert 'jdoe' in hist.changes['body']
+
+
+class TestFindRestorableUsers:
+
+    async def _seed(self, name, uid, *, status, iam):
+        u = User(
+            name=name, email=f'{name}@example.edu',
+            uid=uid, gid=uid, fullname=name.capitalize(),
+            home_directory=f'/home/{name}', type='user',
+            status=await status_link(status), iam=iam,
+        )
+        await u.insert()
+        return u
+
+    async def test_lists_inactive_with_present_iam(self, beanie_client):
+        from ..queries import find_restorable_users
+        now = datetime(2026, 5, 1)
+        # UCDIAMInfo defaults iam_status='present'.
+        await self._seed('returned', 40001, status='inactive',
+                         iam=UCDIAMInfo(
+                             person=UCDIAMPerson(iam_id=1, mothra_id=1),
+                             last_seen_at=now,
+                         ))
+        await self._seed('stillgone', 40002, status='inactive',
+                         iam=UCDIAMInfo(iam_status='missing'))
+        await self._seed('activeuser', 40003, status='active',
+                         iam=UCDIAMInfo(
+                             person=UCDIAMPerson(iam_id=2, mothra_id=2),
+                         ))
+        await self._seed('noiam', 40004, status='inactive', iam=None)
+
+        users = await find_restorable_users()
+        assert [u.name for u in users] == ['returned']
+
+    async def test_status_names_widen_scope(self, beanie_client):
+        from ..queries import find_restorable_users
+        await self._seed('inact', 40011, status='inactive',
+                         iam=UCDIAMInfo(
+                             person=UCDIAMPerson(iam_id=3, mothra_id=3),
+                         ))
+        await self._seed('disab', 40012, status='disabled',
+                         iam=UCDIAMInfo(
+                             person=UCDIAMPerson(iam_id=4, mothra_id=4),
+                         ))
+        await self._seed('offb', 40013, status='offboarding',
+                         iam=UCDIAMInfo(
+                             person=UCDIAMPerson(iam_id=5, mothra_id=5),
+                         ))
+
+        assert [u.name for u in await find_restorable_users()] == ['inact']
+        wide = await find_restorable_users(
+            status_names=('inactive', 'disabled', 'offboarding'),
+        )
+        assert [u.name for u in wide] == ['disab', 'inact', 'offb']
+
+    async def test_unknown_status_names_empty(self, beanie_client):
+        from ..queries import find_restorable_users
+        assert await find_restorable_users(status_names=('nonesuch',)) == []


### PR DESCRIPTION
Audit of every status transition found expiration data surviving reactivation, so LDAP shadowExpire (projected solely from User.expires_at) kept blocking logins for users who regained IAM affiliation:

- SetUserStatus cleared expires_at ONLY on offboarding->active. The reaper flips offboarding->inactive KEEPING the past expiry (intentional: records the deactivation date and keeps shadowExpire blocking the disabled account — now documented in the reap docstring). Reactivating that reaped user (inactive->active) therefore left the past expiry in place — the reported bug. New rule: setting global status to active from ANY non-active status clears expires_at; active->active is untouched so deliberately-expiring active accounts (class users) are safe. Mirrored per-site: an explicit active override from a non-active per-site status clears usi.expires_at.
- Scheduling race: an offboarding user whose expiry lapsed but who reappeared in IAM before the reaper swept was NOT restored by _handle_hit (guard required expires_at > now) — the next reap then deactivated an IAM-present person. Restore now fires for ANY hit on an 'offboarding' user; operator-set inactive/disabled remain non-resurrected. ldap_fingerprint covers status+expires_at, so fixes auto-dirty LDAP sync and clear-on-unset (cbfc7a5) drops shadowExpire.

New `cheeto ng iam restorable` (+ find_restorable_users query): lists users whose status is inactive (widen with --status disabled offboarding) but whose IAM snapshot is 'present' — people who returned after the offboarding window, whom sync-all keeps refreshing (it selects by type, not status) but never auto-restores. Shows iam_id / last_seen_at / iam_synced_at / old expiry; --yaml; footer hints the reactivation command, which now completes the workflow correctly. Live dev-DB run surfaced three real candidates.

Tests: parametrized reactivation-clears-expiry (inactive/disabled/ offboarding), active->active keeps expiry, per-site clear with global untouched, lapsed-expiry hit_restored (race pin), reap-keeps-expiry pin, find_restorable_users scope/edge cases.

Full suite: 541 passed, 1 skipped.