### PR TITLE
Add GroupSiteInfo: explicit group site-presence, mirroring UserSiteInfo

### DIFF
--- a/cheeto/cmds/ng/__init__.py
+++ b/cheeto/cmds/ng/__init__.py
@@ -52,4 +52,4 @@ async def resolve_author(args: Namespace):
 
 
 # Import submodules after registration to avoid circular re-registration
-from . import site, user, user_site, group, slurm, storage, history, migrate, hippo, iam, ldap  # noqa: E402, F401
+from . import site, user, user_site, group, group_site, slurm, storage, history, migrate, hippo, iam, ldap  # noqa: E402, F401

--- a/cheeto/cmds/ng/group.py
+++ b/cheeto/cmds/ng/group.py
@@ -11,8 +11,10 @@ from beanie.operators import In
 
 from ...constants import GROUP_TYPES
 from ...log import Console
+from ...models.base import link_target_id
 from ...models.group import Group
 from ...models.group_membership import GroupMembership
+from ...models.group_site_info import GroupSiteInfo
 from ...models.site import Site
 from ...operations import (
     AddGroupMember,
@@ -118,6 +120,16 @@ def _render_group_panel(data: dict) -> Panel:
         if key in data and data[key] is not None:
             table.add_row(key, str(data[key]))
 
+    if 'sites' in data:
+        names = data['sites']
+        table.add_row('sites', ', '.join(names) if names else '[dim](none)[/]')
+    if data.get('site') and data.get('on_site') is False:
+        table.add_row(
+            'presence',
+            f"[yellow]not attached to site {data['site']} "
+            f"(`group add site`)[/]",
+        )
+
     # Membership is per-site; the roster keys are only present when the
     # command was given a --site.
     if 'members' not in data:
@@ -180,13 +192,11 @@ async def group_list(args: Namespace):
 
     member_counts: dict = {}
     if args.long and groups:
-        from ...models.site import Site as _Site
         query = [In(GroupMembership.group.id, [g.id for g in groups])]
         if args.site:
-            site = await _Site.find_one(_Site.name == args.site)
+            site = await Site.find_one(Site.name == args.site)
             if site is not None:
                 query.append(GroupMembership.site.id == site.id)
-        from ...models.base import link_target_id
         for edge in await GroupMembership.find(*query).to_list():
             gid = link_target_id(edge.group)
             member_counts[gid] = member_counts.get(gid, 0) + 1
@@ -221,8 +231,8 @@ def _(parser: ArgParser):
     parser.add_argument('--type', default=None, choices=list(GROUP_TYPES),
                         help='Filter by group type')
     parser.add_argument('--site', '-s', default=None,
-                        help='Filter to groups present at a site '
-                             '(membership edges or sticky)')
+                        help='Filter to groups attached to a site '
+                             '(GroupSiteInfo presence records)')
     parser.add_argument('--user', '-u', default=None,
                         help='Filter to groups a user is a member of')
     parser.add_argument('--operator', default='AND',
@@ -469,13 +479,25 @@ async def group_remove_slurmer(args: Namespace):
                    help='Show group information')
 async def group_show(args: Namespace):
     console = Console()
-    group = await Group.find_one(Group.name == args.group, 
+    group = await Group.find_one(Group.name == args.group,
                                  fetch_links=True,
                                  with_children=True,
                                  nesting_depth=1)
     if group is None:
         console.print(f'[red]Group {args.group} not found[/]')
         return 1
+
+    gsis = await GroupSiteInfo.find(
+        GroupSiteInfo.group.id == group.id,
+    ).to_list()
+    gsi_site_ids = {
+        sid for g in gsis
+        if (sid := link_target_id(g.site)) is not None
+    }
+    gsi_sites = (
+        await Site.find(In(Site.id, list(gsi_site_ids))).to_list()
+        if gsi_site_ids else []
+    )
 
     if args.site:
         site = await Site.find_one(Site.name == args.site)
@@ -485,9 +507,11 @@ async def group_show(args: Namespace):
         roster = await group_members_at_site(group, site)
         data = _group_to_dict(group, roster=roster)
         data['site'] = args.site
+        data['on_site'] = site.id in gsi_site_ids
         data['slurm_at_site'] = await group_slurm_at_site(group, site)
     else:
         data = _group_to_dict(group)
+    data['sites'] = sorted(s.name for s in gsi_sites)
 
     if args.yaml:
         print_yaml(data)

--- a/cheeto/cmds/ng/group_site.py
+++ b/cheeto/cmds/ng/group_site.py
@@ -1,0 +1,123 @@
+from argparse import Namespace
+
+from ponderosa import ArgParser
+from rich.table import Table
+
+from .. import commands
+from ...log import Console
+from ...operations import AddSiteGroup, BackfillGroupSiteInfo, RemoveSiteGroup
+from ...yaml import print_yaml
+from ._args import group_args, run_per_target, site_args, yaml_args
+
+
+@site_args.apply(required=True)
+@group_args.apply(required=True, multiple=True)
+@commands.register('ng', 'group', 'add', 'site',
+                   help='Add one or more groups to a site')
+async def group_add_site(args: Namespace):
+    console = Console()
+
+    async def _one(name: str) -> None:
+        await AddSiteGroup.run(
+            args.db, args.author,
+            group_name=name, site_name=args.site,
+        )
+
+    return await run_per_target(
+        console, args.group, _one, ok=f'added to {args.site}',
+    )
+
+
+@site_args.apply(required=True)
+@group_args.apply(required=True, multiple=True)
+@commands.register('ng', 'group', 'remove', 'site',
+                   help='Remove one or more groups from a site')
+async def group_remove_site(args: Namespace):
+    console = Console()
+
+    async def _one(name: str) -> None:
+        await RemoveSiteGroup.run(
+            args.db, args.author,
+            group_name=name, site_name=args.site, force=args.force,
+        )
+
+    code = await run_per_target(
+        console, args.group, _one, ok=f'removed from {args.site}',
+    )
+    if code == 0:
+        console.print(
+            '[dim]LDAP entries are removed by the next prune '
+            '(`ng ldap prune`).[/]'
+        )
+    return code
+
+
+@group_remove_site.args()
+def _(parser: ArgParser):
+    parser.add_argument('--force', '-f', action='store_true', default=False,
+                        help='Also delete membership edges at the site '
+                             '(slurm/storage/sticky references still block)')
+
+
+@yaml_args.apply()
+@site_args.apply()
+@commands.register('ng', 'group', 'backfill-sites',
+                   help='Create explicit group-site presence records from '
+                        'imputed presence (membership edges, sticky groups, '
+                        'slurm accounts, storage, personal groups)')
+async def group_backfill_sites(args: Namespace):
+    console = Console()
+    # A dry run writes nothing — skip the History row too.
+    report = await BackfillGroupSiteInfo.run(
+        args.db, args.author,
+        site_name=args.site, dry_run=args.dry_run,
+        skip_history=args.dry_run,
+    )
+
+    if args.yaml:
+        print_yaml(report)
+        return
+
+    created_col = 'would create' if args.dry_run else 'created'
+    table = Table(
+        title='GroupSiteInfo backfill'
+              + (' (dry run)' if args.dry_run else ''),
+    )
+    table.add_column('site', style='green', no_wrap=True)
+    table.add_column(created_col, justify='right')
+    table.add_column('existing', justify='right')
+    table.add_column('extras', justify='right')
+    for site_name, row in sorted(report.items()):
+        table.add_row(
+            site_name,
+            str(len(row['created'])),
+            str(row['existing']),
+            str(len(row['extras'])),
+        )
+    console.print(table)
+
+    def _names(names: list[str]) -> str:
+        # Real sites run to thousands; keep the terminal readable and
+        # leave the full list to --yaml.
+        if len(names) > 25:
+            shown = ', '.join(names[:25])
+            return f'{shown}, … and {len(names) - 25} more (--yaml for all)'
+        return ', '.join(names)
+
+    for site_name, row in sorted(report.items()):
+        if row['created']:
+            console.print(
+                f'[bold]{site_name}[/] {created_col}: '
+                + _names(row['created'])
+            )
+        if row['extras']:
+            console.print(
+                f'[bold]{site_name}[/] [yellow]explicit-only (no imputed '
+                f'source)[/]: ' + _names(row['extras'])
+            )
+
+
+@group_backfill_sites.args()
+def _(parser: ArgParser):
+    parser.add_argument('--dry-run', action='store_true', default=False,
+                        help='Report what would be created without writing')

--- a/cheeto/cmds/ng/site.py
+++ b/cheeto/cmds/ng/site.py
@@ -11,6 +11,7 @@ from rich.table import Table
 from .. import commands
 from . import parent
 from ...log import Console
+from ...models.group_site_info import GroupSiteInfo
 from ...models.site import Site
 from ...operations import (
     AddSiteAlias,
@@ -161,10 +162,17 @@ async def _site_to_dict(site: Site) -> dict:
             resolve_site_storage_settings(site.storage),
         )
     )
+    # Count, not names: post-backfill every personal group at the site has
+    # a presence record — the list would be thousands long. Names via
+    # `ng group list --site`.
+    group_count = await GroupSiteInfo.find(
+        GroupSiteInfo.site.id == site.id,
+    ).count()
     return {
         'name': site.name,
         'fqdn': site.fqdn,
         'aliases': site.aliases,
+        'group_count': group_count,
         'sticky_groups': sticky_groups,
         'sticky_slurm_accounts': sticky_accounts,
         'default_slurm_account': default_account,
@@ -185,6 +193,11 @@ def _render_site_panel(data: dict) -> Panel:
 
     aliases = data.get('aliases')
     table.add_row('aliases', ', '.join(aliases) if aliases else '[dim](none)[/]')
+
+    table.add_row(
+        'groups',
+        f"{data['group_count']} [dim](`group list --site` for names)[/]",
+    )
 
     groups = data['sticky_groups']
     table.add_row(

--- a/cheeto/ldap_async.py
+++ b/cheeto/ldap_async.py
@@ -565,7 +565,12 @@ class AsyncLDAPManager:
                 new = (current | add_set) - remove_set
             if new == current:
                 return
-            entry[members_attr] = sorted(new)
+            if new:
+                entry[members_attr] = sorted(new)
+            else:
+                # Replace-with-empty deletes the attribute per RFC 4511;
+                # be explicit about it (mirrors _modify_attrs' clear path).
+                del entry[members_attr]
             await entry.modify()
         await self._pooled_op(_op)
 

--- a/cheeto/models/__init__.py
+++ b/cheeto/models/__init__.py
@@ -31,6 +31,7 @@ from .storage import (
 from .user_site_info import UserSiteInfo
 from .site_association import SiteAssociation
 from .group_membership import GroupMembership
+from .group_site_info import GroupSiteInfo
 from .history import History
 from .hippo import HippoEvent
 
@@ -45,6 +46,7 @@ AccessGroup.model_rebuild()
 StatusGroup.model_rebuild()
 UserSiteInfo.model_rebuild()
 GroupMembership.model_rebuild()
+GroupSiteInfo.model_rebuild()
 SlurmAccount.model_rebuild()
 StorageVolume.model_rebuild()   # self-ref Link['StorageVolume']
 Storage.model_rebuild()
@@ -52,8 +54,9 @@ Storage.model_rebuild()
 # references, not Links — links in embedded models silently degrade to
 # inline snapshots (see models/base.py::DocRef) — so they need no rebuild.
 
-# NOTE: SiteAssociation is the abstract base for GroupMembership; it has no
-# collection of its own and is intentionally NOT in ALL_MODELS.
+# NOTE: SiteAssociation is the abstract base for GroupMembership and
+# GroupSiteInfo; it has no collection of its own and is intentionally NOT in
+# ALL_MODELS.
 ALL_MODELS = [
     Site,
     User,
@@ -63,6 +66,7 @@ ALL_MODELS = [
     StatusGroup,
     UserSiteInfo,
     GroupMembership,
+    GroupSiteInfo,
     SlurmAccount,
     SlurmAllocation,
     SlurmPartition,

--- a/cheeto/models/group_site_info.py
+++ b/cheeto/models/group_site_info.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pymongo
+from beanie import Delete, Insert, Link, after_event
+from pymongo import IndexModel
+
+from .base import link_target_id
+from .group import Group
+from .ldap_sync import ldap_touch, queue_ldap_touch
+from .site_association import SiteAssociation
+
+
+class GroupSiteInfo(SiteAssociation):
+    """Explicit group presence at a site — the group analog of UserSiteInfo.
+
+    One document per `(group, site)`. Presence is *authoritative*: readers
+    (LDAP site sync, puppet export, `find_groups --site`) project exactly the
+    groups with a GroupSiteInfo, while `GroupMembership` edges continue to
+    govern membership and roles *within* a present group. Auto-created by
+    every attach path via `operations.group_site.ensure_group_site`; removed
+    only explicitly (`RemoveSiteGroup`, `user remove site` for personal
+    groups) or by the DeleteGroup/DeleteUser/DeleteSite cascades.
+    """
+
+    group: Link[Group]
+
+    @after_event(Insert, Delete)
+    async def mark_group_ldap_dirty(self) -> None:
+        # Presence drives whether the group's entry exists in the site's
+        # LDAP tree. Sessionless write — deferred past any active Operation
+        # transaction (see ldap_sync docstring). with_children=True so a
+        # stray reference to a polymorphic subclass row still resolves.
+        group_id = link_target_id(self.group)
+        await queue_ldap_touch(
+            lambda: Group.find_one(
+                Group.id == group_id, with_children=True,
+            ).update(ldap_touch())
+        )
+
+    class Settings:
+        name = 'group_site_info'
+        indexes = [
+            IndexModel(
+                [('group', pymongo.ASCENDING), ('site', pymongo.ASCENDING)],
+                unique=True,
+            ),
+            IndexModel([('site', pymongo.ASCENDING)]),
+        ]

--- a/cheeto/operations/__init__.py
+++ b/cheeto/operations/__init__.py
@@ -46,6 +46,12 @@ from .group import (
     DeleteGroup,
     SeedAccessStatusGroups,
 )
+from .group_site import (
+    AddSiteGroup,
+    BackfillGroupSiteInfo,
+    RemoveSiteGroup,
+    ensure_group_site,
+)
 from .group_membership import (
     AddGroupMember,
     AddGroupSlurmer,

--- a/cheeto/operations/group.py
+++ b/cheeto/operations/group.py
@@ -20,6 +20,7 @@ from ..models.base import link_target_id
 from ..models.user import User
 from ..queries.group import find_group_by_name, gather_group_references
 from .base import Operation
+from .group_site import ensure_group_site
 
 
 # Standard set of access types and their LDAP groupnames. Seeded into
@@ -199,6 +200,7 @@ class CreateGroupFromSponsor(Operation):
         gid = MIN_PIGROUP_GID + sponsor.uid
         group = Group(name=self.group_name, gid=gid, type='group')
         await group.insert(session=session)
+        await ensure_group_site(group, site, session)
 
         # The sponsor is both a member and sponsor of their own group at the
         # creating site.
@@ -400,6 +402,8 @@ class DeleteGroup(Operation):
             await acct.delete(session=session)
         for edge in refs.memberships:
             await edge.delete(session=session)
+        for gsi in refs.site_infos:
+            await gsi.delete(session=session)
         for storage in refs.storages:
             await storage.delete(session=session)
         for volume in refs.storage_volumes:

--- a/cheeto/operations/group_membership.py
+++ b/cheeto/operations/group_membership.py
@@ -10,6 +10,7 @@ from ..models.group_membership import GroupMembership, MembershipRole
 from ..models.site import Site
 from ..models.user import User
 from .base import Operation
+from .group_site import ensure_group_site
 
 
 class _GroupMembershipOp(Operation):
@@ -71,6 +72,8 @@ class _AddToGroup(_GroupMembershipOp):
 
     async def execute(self, session: AsyncClientSession) -> None:
         group, user, site = await self._resolve()
+        # Any role edge implies the group is present at the site.
+        await ensure_group_site(group, site, session)
         edge = await self._find_edge(user, group, site)
         if edge is None:
             edge = GroupMembership(

--- a/cheeto/operations/group_site.py
+++ b/cheeto/operations/group_site.py
@@ -1,0 +1,289 @@
+"""Operations for explicit group site-presence (`GroupSiteInfo`).
+
+`ensure_group_site` is the shared idempotent attach helper called from every
+code path that ties a group to a site (membership adds, sponsor-group
+creation, sticky adds, slurm accounts, storage provisioning, user site
+adds). `AddSiteGroup`/`RemoveSiteGroup` are the explicit CLI-facing ops, and
+`BackfillGroupSiteInfo` materializes presence records for pre-existing data
+from the imputed sources.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from beanie.operators import In
+from pymongo import AsyncMongoClient
+from pymongo.asynchronous.client_session import AsyncClientSession
+
+from ..models.base import link_target_id
+from ..models.group import AccessGroup, Group, StatusGroup
+from ..models.group_membership import GroupMembership
+from ..models.group_site_info import GroupSiteInfo
+from ..models.site import Site
+from ..models.slurm import SlurmAccount
+from ..models.storage import Storage
+from ..models.user import User
+from ..queries.group import (
+    find_group_by_name,
+    imputed_group_ids_at_site,
+    resolve_group_names,
+)
+from .base import Operation
+
+
+async def ensure_group_site(
+    group: Group, site: Site, session: AsyncClientSession | None,
+) -> GroupSiteInfo:
+    """Idempotent find-or-insert of the `(group, site)` presence record.
+
+    The find_one must pass `session`: inside a transaction, sessionless
+    reads cannot see the transaction's own uncommitted inserts, and a
+    duplicate insert would abort the whole transaction (see the
+    CreateClassUsers docstring). Cross-transaction races are backstopped by
+    the unique (group, site) index — the losing transaction aborts and a
+    re-run succeeds; do NOT catch DuplicateKeyError here, a write error
+    inside a Mongo transaction is unrecoverable in-transaction.
+    """
+    existing = await GroupSiteInfo.find_one(
+        GroupSiteInfo.group.id == group.id,
+        GroupSiteInfo.site.id == site.id,
+        session=session,
+    )
+    if existing is not None:
+        return existing
+    gsi = GroupSiteInfo(group=group, site=site)
+    await gsi.insert(session=session)
+    return gsi
+
+
+class _SiteGroupOp(Operation):
+    """Shared resolution/refusals for the explicit add/remove-site ops."""
+
+    def __init__(
+        self,
+        client: AsyncMongoClient,
+        author: User | None,
+        *,
+        group_name: str,
+        site_name: str,
+    ) -> None:
+        super().__init__(client, author)
+        self.group_name = group_name
+        self.site_name = site_name
+
+    async def _resolve(self) -> tuple[Group, Site]:
+        group = await find_group_by_name(self.group_name)
+        if group is None:
+            raise ValueError(f'Group {self.group_name} does not exist')
+        if isinstance(group, (AccessGroup, StatusGroup)):
+            raise ValueError(
+                f'Group {self.group_name} is a seeded access/status group; '
+                f'those exist at every site and have no per-site presence '
+                f'record'
+            )
+        if group.type == 'user':
+            raise ValueError(
+                f'Group {self.group_name} is a personal group; its site '
+                f'presence follows its owner (`user add site` / '
+                f'`user remove site`)'
+            )
+        site = await Site.find_one(Site.name == self.site_name)
+        if site is None:
+            raise ValueError(f'Site {self.site_name} does not exist')
+        return group, site
+
+    def describe(self) -> dict[str, Any]:
+        return {'group': self.group_name, 'site': self.site_name}
+
+
+class AddSiteGroup(_SiteGroupOp):
+    op_name = 'add_site_group'
+
+    async def execute(self, session: AsyncClientSession) -> GroupSiteInfo:
+        group, site = await self._resolve()
+        existing = await GroupSiteInfo.find_one(
+            GroupSiteInfo.group.id == group.id,
+            GroupSiteInfo.site.id == site.id,
+        )
+        if existing is not None:
+            raise ValueError(
+                f'Group {self.group_name} already on site {self.site_name}'
+            )
+        gsi = GroupSiteInfo(group=group, site=site)
+        await gsi.insert(session=session)
+        return gsi
+
+
+class RemoveSiteGroup(_SiteGroupOp):
+    """Detach a group from a site.
+
+    Slurm accounts, storage records, and sticky references block removal
+    even with `force` — each has its own decommission path, and a lingering
+    sticky ref would make the next backfill recreate the presence record.
+    Membership edges block unless `force`, which deletes them per-document
+    so the LDAP dirty hooks fire. The group's LDAP entry at the site is
+    removed by the next prune, not immediately.
+    """
+
+    op_name = 'remove_site_group'
+
+    def __init__(
+        self,
+        client: AsyncMongoClient,
+        author: User | None,
+        *,
+        group_name: str,
+        site_name: str,
+        force: bool = False,
+    ) -> None:
+        super().__init__(
+            client, author, group_name=group_name, site_name=site_name,
+        )
+        self.force = force
+        self._memberships_deleted = 0
+
+    async def execute(self, session: AsyncClientSession) -> dict[str, int]:
+        group, site = await self._resolve()
+        gsi = await GroupSiteInfo.find_one(
+            GroupSiteInfo.group.id == group.id,
+            GroupSiteInfo.site.id == site.id,
+        )
+        if gsi is None:
+            raise ValueError(
+                f'Group {self.group_name} not on site {self.site_name}'
+            )
+
+        blockers: list[str] = []
+        if await SlurmAccount.find_one(
+            SlurmAccount.group.id == group.id,
+            SlurmAccount.site.id == site.id,
+        ):
+            blockers.append('a Slurm account (remove it first)')
+        if await Storage.find_one(
+            Storage.group.id == group.id,
+            Storage.site.id == site.id,
+        ):
+            blockers.append('storage records (delete group storage first)')
+        if group.id in set(site.group.sticky):
+            blockers.append(
+                'a sticky-group entry (`site remove sticky-group` first)'
+            )
+        if blockers:
+            raise ValueError(
+                f'Group {self.group_name} still has {"; ".join(blockers)} '
+                f'at {self.site_name}'
+            )
+
+        edges = await GroupMembership.find(
+            GroupMembership.group.id == group.id,
+            GroupMembership.site.id == site.id,
+        ).to_list()
+        if edges and not self.force:
+            raise ValueError(
+                f'Group {self.group_name} has {len(edges)} membership '
+                f'edge(s) at {self.site_name}; pass --force to delete them'
+            )
+        for edge in edges:
+            await edge.delete(session=session)
+        await gsi.delete(session=session)
+        self._memberships_deleted = len(edges)
+        return {'memberships_deleted': self._memberships_deleted}
+
+    def describe(self) -> dict[str, Any]:
+        return {
+            'group': self.group_name,
+            'site': self.site_name,
+            'force': self.force,
+            'memberships_deleted': self._memberships_deleted,
+        }
+
+
+class BackfillGroupSiteInfo(Operation):
+    """Create `GroupSiteInfo` records for groups whose site presence is
+    currently only imputed (membership edges, sticky refs, slurm accounts,
+    storage, personal groups of site users). Must run once per deployment
+    before the GSI-based readers (LDAP site sync/prune, puppet export) see
+    real data; safe to re-run any time.
+    """
+
+    op_name = 'backfill_group_site_info'
+    # Whole-collection scan across sites; each insert is independently
+    # idempotent under the unique (group, site) index, so a bare session is
+    # fine and avoids transactionLifetimeLimit on large backfills.
+    transactional = False
+
+    def __init__(
+        self,
+        client: AsyncMongoClient,
+        author: User | None,
+        *,
+        site_name: str | None = None,
+        dry_run: bool = False,
+    ) -> None:
+        super().__init__(client, author)
+        self.site_name = site_name
+        self.dry_run = dry_run
+        self._report: dict[str, dict[str, Any]] = {}
+
+    async def execute(
+        self, session: AsyncClientSession,
+    ) -> dict[str, dict[str, Any]]:
+        if self.site_name is not None:
+            site = await Site.find_one(Site.name == self.site_name)
+            if site is None:
+                raise ValueError(f'Site {self.site_name} does not exist')
+            sites = [site]
+        else:
+            sites = await Site.find_all().to_list()
+
+        report: dict[str, dict[str, Any]] = {}
+        for site in sites:
+            imputed = await imputed_group_ids_at_site(site)
+            existing_gsis = await GroupSiteInfo.at_site(site).to_list()
+            existing_ids = {
+                link_target_id(g.group) for g in existing_gsis
+            }
+            existing_ids.discard(None)
+            missing = imputed - existing_ids
+            # Explicit presence with no imputed source — informational;
+            # legitimate for groups attached ahead of any members/resources.
+            extras = existing_ids - imputed
+
+            groups = (
+                await Group.find(
+                    In(Group.id, list(missing)), with_children=True,
+                ).to_list()
+                if missing else []
+            )
+            created: list[str] = []
+            for group in sorted(groups, key=lambda g: g.name):
+                if not self.dry_run:
+                    await GroupSiteInfo(group=group, site=site).insert(
+                        session=session,
+                    )
+                created.append(group.name)
+
+            report[site.name] = {
+                'created': created,
+                'existing': len(existing_ids),
+                'extras': await resolve_group_names(list(extras)),
+            }
+
+        self._report = report
+        return report
+
+    def describe(self) -> dict[str, Any]:
+        # Counts only — keep History rows bounded on big backfills.
+        return {
+            'dry_run': self.dry_run,
+            'site': self.site_name,
+            'sites': {
+                name: {
+                    'created': len(r['created']),
+                    'existing': r['existing'],
+                    'extras': len(r['extras']),
+                }
+                for name, r in self._report.items()
+            },
+        }

--- a/cheeto/operations/ldap.py
+++ b/cheeto/operations/ldap.py
@@ -43,6 +43,8 @@ from ..ldap_async import (
     LDAPUserRecord,
 )
 from ..models.group import AccessGroup, Group, StatusGroup
+from ..models.group_membership import GroupMembership
+from ..models.group_site_info import GroupSiteInfo
 from ..models.site import Site
 from ..models.storage import Storage
 from ..models.user import SshKey, User
@@ -51,7 +53,11 @@ from ..queries.access_status import (
     resolve_access_ldapnames,
     resolve_status_ldapname,
 )
-from ..queries.group import effective_group_members, effective_user_groups
+from ..queries.group import (
+    effective_group_members,
+    effective_user_groups,
+    site_present_group_ids,
+)
 from ..queries.user import (
     effective_access_links,
     effective_status_link,
@@ -283,8 +289,9 @@ class SyncUserToLDAP(Operation):
         # with the special groups above. Include them so the reconcile keeps
         # the user in their lab/sponsor groups instead of stripping them.
         # `effective_user_groups` returns member-role edges plus sticky
-        # groups — the same membership set SyncGroupToLDAP projects from the
-        # group side via `effective_group_members`.
+        # groups, gated by GroupSiteInfo presence — the same membership set
+        # SyncGroupToLDAP projects from the group side (a detached group is
+        # excluded so the reconcile doesn't fight prune).
         posix_groups, _sticky_ids = await effective_user_groups(user, site)
         target_groups.update(g.name for g in posix_groups)
 
@@ -437,23 +444,26 @@ class SyncGroupToLDAP(Operation):
         if site is None:
             raise ValueError(f'Site {self.sitename!r} does not exist')
 
-        member_names = await self._members_at_site(group, site)
+        gsi = await GroupSiteInfo.find_one(
+            GroupSiteInfo.group.id == group.id,
+            GroupSiteInfo.site.id == site.id,
+        )
+        if gsi is None:
+            # GroupSiteInfo is the presence authority; force/full override
+            # *dirtiness*, not presence. Steady state — watermark it (a
+            # later attach re-dirties via the GroupSiteInfo hook). Any
+            # stale LDAP entry is removed by the next prune.
+            self._outcome = 'skipped_not_on_site'
+            await self._write_watermark(group, watermark, session)
+            return LDAPSyncResult(
+                name=self.groupname, outcome=self._outcome,
+                extra={'member_count': 0},
+            )
 
-        if not member_names and not self.force:
-            # A user (personal) group must be projected to every site its
-            # owner is on, even with no member edges (the owner's primary
-            # membership is implicit via passwd gidNumber). Other member-less
-            # groups are not projected here.
-            if not (
-                group.type == 'user'
-                and await self._owner_present_at_site(group, site)
-            ):
-                self._outcome = 'skipped_no_members_on_site'
-                await self._write_watermark(group, watermark, session)
-                return LDAPSyncResult(
-                    name=self.groupname, outcome=self._outcome,
-                    extra={'member_count': 0},
-                )
+        # A present group with zero members on the site is written as an
+        # empty entry — the exact analogue of a user with a UserSiteInfo
+        # and no group memberships.
+        member_names = await self._members_at_site(group, site)
 
         if self.force:
             await self.ldap.delete_group(self.groupname)
@@ -507,18 +517,6 @@ class SyncGroupToLDAP(Operation):
             return set()
         users = await User.find(In(User.id, present_ids)).to_list()
         return {u.name for u in users}
-
-    async def _owner_present_at_site(self, group: Group, site: Site) -> bool:
-        """A user (personal) group must exist on every site its owner is on.
-        The personal group shares the owner's name and gid (CreateUser)."""
-        owner = await User.find_one(User.name == group.name)
-        if owner is None or owner.gid != group.gid:
-            return False
-        usi = await UserSiteInfo.find_one(
-            UserSiteInfo.user.id == owner.id,
-            UserSiteInfo.site.id == site.id,
-        )
-        return usi is not None
 
     def describe(self) -> dict[str, Any]:
         return {
@@ -727,8 +725,10 @@ class PruneSiteLDAP(Operation):
 
     Three phases (`scope` controls which run):
       - users: ldap users not in beanie's User collection
-      - groups: ldap groups (under groups_ou) not in beanie's groups
-        collection. AccessGroup/StatusGroup names are NEVER pruned.
+      - groups: ldap groups (under groups_ou) with no GroupSiteInfo at
+        this site — a group detached from the site is pruned here even if
+        the Group document still exists. AccessGroup/StatusGroup names and
+        `ldap.ignore` records are NEVER pruned.
       - automounts: automountKey values in auto.home/auto.group not
         in beanie's Storage rows.
 
@@ -820,21 +820,50 @@ class PruneSiteLDAP(Operation):
 
     async def _plan_groups(self) -> list[str]:
         ldap_groups = await self.ldap.list_groups()
-        beanie_names = {
-            g.name for g in
-            await Group.find_all(with_children=True).to_list()
-        }
+        site = await Site.find_one(Site.name == self.sitename)
+        if site is None:
+            raise ValueError(f'Site {self.sitename!r} does not exist')
+
+        present_ids = await site_present_group_ids(site)
+        if not present_ids and await GroupMembership.at_site(site).count():
+            # Zero presence records while the site plainly has group data
+            # means the backfill hasn't run — refuse to plan a site-wide
+            # wipe (max_deletions is only the second line of defense).
+            raise LDAPPruneAborted(
+                f'No GroupSiteInfo records at {self.sitename!r} but '
+                f'membership edges exist; run `cheeto ng group '
+                f'backfill-sites` before pruning groups.',
+                would_delete={},
+            )
+        present_names = (
+            {
+                g.name for g in await Group.find(
+                    In(Group.id, list(present_ids)), with_children=True,
+                ).to_list()
+            }
+            if present_ids else set()
+        )
+
+        # Exemptions: access/status groups are global infrastructure that
+        # exists in every site's tree and never carries a GroupSiteInfo;
+        # ldap.ignore records are never managed by cheeto (the old global
+        # keep-set honored that contract implicitly).
         access_names = {
             ag.name for ag in await AccessGroup.find_all().to_list()
         }
         status_names = {
             sg.name for sg in await StatusGroup.find_all().to_list()
         }
-        protected = access_names | status_names
+        ignored_names = {
+            g.name for g in await Group.find(
+                Group.ldap.ignore == True,  # noqa: E712 — beanie query syntax
+                with_children=True,
+            ).to_list()
+        }
+        keep = present_names | access_names | status_names | ignored_names
         return [
             g.groupname for g in ldap_groups
-            if g.groupname not in protected
-            and g.groupname not in beanie_names
+            if g.groupname not in keep
         ]
 
     async def _plan_automounts(self) -> list[str]:
@@ -873,7 +902,7 @@ class PruneSiteLDAP(Operation):
 
 _SYNC_TALLY_KEYS = (
     'created', 'updated', 'recreated', 'memberships_only', 'no_op',
-    'membership_diffed', 'skipped_special', 'skipped_no_members_on_site',
+    'membership_diffed', 'skipped_special', 'skipped_not_on_site',
     'skipped_inactive', 'skipped_clean', 'skipped_ignored',
     'transient_error', 'error',
 )
@@ -964,10 +993,16 @@ class SyncSiteLDAP(Operation):
             )
 
         if 'groups' in self.scope:
-            # Group.find_all() against the base class is polymorphic-aware:
-            # subclasses (AccessGroup/StatusGroup) are filtered by _class_id
-            # when with_children is omitted.
-            groups = await Group.find_all().to_list()
+            # Presence-scoped: exactly the groups with a GroupSiteInfo at
+            # this site. The base-class find (no with_children) is
+            # polymorphic-aware — AccessGroup/StatusGroup rows are filtered
+            # by _class_id even if a stray GSI points at one; their entries
+            # are managed by BootstrapLDAPSite + SyncUserToLDAP instead.
+            present_ids = await site_present_group_ids(site)
+            groups = (
+                await Group.find(In(Group.id, list(present_ids))).to_list()
+                if present_ids else []
+            )
             group_names = self._gate_records(groups, self._groups_tally)
             await self._run_per_record(
                 self._groups_tally, 'group', group_names,

--- a/cheeto/operations/site.py
+++ b/cheeto/operations/site.py
@@ -13,6 +13,7 @@ from ..models.slurm import SlurmAccount, SlurmAllocation
 from ..models.user import User
 from ..models.user_site_info import UserSiteInfo
 from .base import Operation
+from .group_site import ensure_group_site
 
 
 class CreateSite(Operation):
@@ -94,6 +95,9 @@ class AddStickyGroup(Operation):
                 f'Group {self.groupname!r} is an access/status group; not '
                 f'eligible for site.group.sticky'
             )
+        # Before the idempotency early-return so a re-run heals a missing
+        # presence record.
+        await ensure_group_site(group, site, session)
         if group.id in set(site.group.sticky):
             return  # idempotent
         site.group.sticky.append(group.id)

--- a/cheeto/operations/slurm.py
+++ b/cheeto/operations/slurm.py
@@ -32,6 +32,7 @@ from ..slurm_sync import (
     reconcile,
 )
 from .base import UNSET, Operation
+from .group_site import ensure_group_site
 
 
 _QOS_ALLOC_FIELDS = ('group_limits', 'user_limits', 'job_limits')
@@ -464,6 +465,7 @@ class CreateSlurmAccount(Operation):
             group=group, site=site, limits=limits, coordinators=coordinators,
         )
         await account.insert(session=session)
+        await ensure_group_site(group, site, session)
         self._account = account
         return account
 
@@ -819,6 +821,8 @@ class ProvisionSlurmAllocation(Operation):
             account = SlurmAccount(group=group, site=site)
             await account.insert(session=session)
             self.created_account = True
+        # Unconditional: also self-heals presence for pre-existing accounts.
+        await ensure_group_site(group, site, session)
         partition = await SlurmPartition.find_one(
             SlurmPartition.name == self.partition_name,
             SlurmPartition.site.id == site.id,

--- a/cheeto/operations/storage.py
+++ b/cheeto/operations/storage.py
@@ -28,6 +28,7 @@ from ..models.user import User
 from ..queries.storage import get_storage, list_site_volumes
 from ..utils import size_to_megs_exact
 from .base import Operation
+from .group_site import ensure_group_site
 
 
 def _backend_config_kwargs(backend: str) -> dict[str, Any]:
@@ -382,6 +383,8 @@ async def _provision_home_storage(
         static_mount=smount,
     )
     await storage.insert(session=session)
+    # The home's personal group must be present at the site.
+    await ensure_group_site(group, site, session)
     return storage, mechanism
 
 
@@ -607,6 +610,7 @@ async def _provision_group_storage(
         static_mount=smount,
     )
     await storage.insert(session=session)
+    await ensure_group_site(group, site, session)
     return storage, mechanism
 
 

--- a/cheeto/operations/user.py
+++ b/cheeto/operations/user.py
@@ -34,6 +34,7 @@ from ..queries.user import (
     gather_user_references,
 )
 from .base import Operation
+from .group_site import ensure_group_site
 from .storage import _provision_home_storage
 
 
@@ -395,6 +396,11 @@ class CreateClassUsers(Operation):
             )
         self._base_uid = base_uid
 
+        if group is not None:
+            # The direct GroupMembership inserts below bypass _AddToGroup,
+            # so materialize the class group's presence here.
+            await ensure_group_site(group, site, session)
+
         results: list[tuple[User, str]] = []
         for i, (name, password) in enumerate(zip(self.names, self.passwords)):
             op = CreateUser(
@@ -408,6 +414,9 @@ class CreateClassUsers(Operation):
             await UserSiteInfo(
                 user=user, site=site, status=active_sg,
             ).insert(session=session)
+            # Explicit even though home provisioning also ensures it —
+            # presence must not depend on the home-storage configuration.
+            await ensure_group_site(personal_group, site, session)
             if group is not None:
                 await GroupMembership(
                     user=user, group=group, site=site, roles=['member'],
@@ -1001,6 +1010,8 @@ class DeleteUser(Operation):
                         if g != refs.personal_group.id
                     ]
                     await site.save(session=session)
+            for gsi in refs.personal_group_site_infos:
+                await gsi.delete(session=session)
             await refs.personal_group.delete(session=session)
 
         await user.delete(session=session)

--- a/cheeto/operations/user_site.py
+++ b/cheeto/operations/user_site.py
@@ -5,11 +5,20 @@ from typing import Any
 from pymongo import AsyncMongoClient
 from pymongo.asynchronous.client_session import AsyncClientSession
 
-from ..models.group import StatusGroup
+from ..models.group import Group, StatusGroup
+from ..models.group_site_info import GroupSiteInfo
 from ..models.site import Site
+from ..models.storage import Storage
 from ..models.user import User
 from ..models.user_site_info import UserSiteInfo
 from .base import Operation
+from .group_site import ensure_group_site
+
+
+async def _find_personal_group(user: User) -> Group | None:
+    """The user's personal group (same name, type='user'). May be absent
+    for rows predating personal-group creation."""
+    return await Group.find_one(Group.name == user.name, Group.type == 'user')
 
 
 class AddSiteUser(Operation):
@@ -51,6 +60,13 @@ class AddSiteUser(Operation):
         active = await StatusGroup.find_one(StatusGroup.status_name == 'active')
         usi = UserSiteInfo(user=user, site=site, status=active)
         await usi.insert(session=session)
+
+        # The personal group follows its owner onto the site so the user's
+        # primary-gid group resolves there.
+        personal_group = await _find_personal_group(user)
+        if personal_group is not None:
+            await ensure_group_site(personal_group, site, session)
+
         self._usi = usi
         return usi
 
@@ -72,6 +88,7 @@ class RemoveSiteUser(Operation):
         super().__init__(client, author)
         self.user_name = user_name
         self.site_name = site_name
+        self._kept_group_site = False
 
     async def execute(self, session: AsyncClientSession) -> None:
         user = await User.find_one(User.name == self.user_name)
@@ -93,5 +110,28 @@ class RemoveSiteUser(Operation):
 
         await usi.delete(session=session)
 
+        # The personal group leaves with its owner — unless its home
+        # storage still exists at the site (rehome/cleanup pending), in
+        # which case presence is kept so the export still resolves the gid.
+        personal_group = await _find_personal_group(user)
+        if personal_group is not None:
+            home_storage = await Storage.find_one(
+                Storage.group.id == personal_group.id,
+                Storage.site.id == site.id,
+            )
+            if home_storage is not None:
+                self._kept_group_site = True
+            else:
+                gsi = await GroupSiteInfo.find_one(
+                    GroupSiteInfo.group.id == personal_group.id,
+                    GroupSiteInfo.site.id == site.id,
+                )
+                if gsi is not None:
+                    await gsi.delete(session=session)
+
     def describe(self) -> dict[str, Any]:
-        return {'user': self.user_name, 'site': self.site_name}
+        return {
+            'user': self.user_name,
+            'site': self.site_name,
+            'kept_group_site': self._kept_group_site,
+        }

--- a/cheeto/queries/__init__.py
+++ b/cheeto/queries/__init__.py
@@ -17,8 +17,10 @@ from .group import (
     find_group_by_name,
     find_groups,
     group_members_at_site,
+    imputed_group_ids_at_site,
     is_sticky_group,
     resolve_group_names,
+    site_present_group_ids,
     user_groups_at_site,
 )
 from .puppet_legacy import site_to_puppet_legacy

--- a/cheeto/queries/group.py
+++ b/cheeto/queries/group.py
@@ -1,10 +1,14 @@
-"""Group-membership query helpers over per-site `GroupMembership` edges.
+"""Group query helpers: presence via `GroupSiteInfo`, membership via
+per-site `GroupMembership` edges.
 
-Membership is per-site: a `GroupMembership(user, group, site, roles)` edge
-records the capacities in which a user participates in a group at a site.
-`effective_group_members(group, site)` is the central join — it also unions
-in `site.group.sticky` so that when `group` is sticky, every user with a
-`UserSiteInfo` at the site counts as a member even without an explicit edge.
+Presence and membership are distinct: a `GroupSiteInfo(group, site)` record
+is the authority on *which groups exist at a site* (LDAP projection, puppet
+export, `find_groups --site`), while `GroupMembership(user, group, site,
+roles)` edges record the capacities in which users participate in a present
+group. `effective_group_members(group, site)` is the central membership
+join — it also unions in `site.group.sticky` so that when `group` is sticky,
+every user with a `UserSiteInfo` at the site counts as a member even without
+an explicit edge (sticky is a membership modifier, not a presence source).
 Used by LDAP projection (`SyncGroupToLDAP._members_at_site`) and the
 `--site`-scoped group filter on `find_users`.
 """
@@ -18,8 +22,9 @@ from beanie import PydanticObjectId
 from beanie.operators import In
 
 from ..models.base import link_target_id
-from ..models.group import Group
+from ..models.group import AccessGroup, Group, StatusGroup
 from ..models.group_membership import GroupMembership
+from ..models.group_site_info import GroupSiteInfo
 from ..models.hippo import HippoEvent
 from ..models.site import Site
 from ..models.slurm import SlurmAccount, SlurmAssociation
@@ -45,6 +50,61 @@ def _sticky_group_ids(site: Site) -> set[PydanticObjectId]:
 def is_sticky_group(group: Group, site: Site) -> bool:
     """True when `group` appears in `site.group.sticky`."""
     return group.id in _sticky_group_ids(site)
+
+
+async def site_present_group_ids(site: Site) -> set[PydanticObjectId]:
+    """The presence authority: ids of groups with a `GroupSiteInfo` at
+    `site`. Every reader that needs "which groups are on this site" goes
+    through here so the definition can never drift."""
+    gsis = await GroupSiteInfo.find(GroupSiteInfo.site.id == site.id).to_list()
+    ids = {link_target_id(g.group) for g in gsis}
+    ids.discard(None)
+    return ids
+
+
+async def imputed_group_ids_at_site(site: Site) -> set[PydanticObjectId]:
+    """Group ids whose presence at `site` is *implied* by existing records:
+    membership edges ∪ `site.group.sticky` ∪ SlurmAccount(group, site) ∪
+    Storage.group at the site ∪ personal groups of users with a
+    UserSiteInfo. Access/status rows are excluded. This is the presence
+    definition the GroupSiteInfo backfill materializes; live reads use
+    `site_present_group_ids` instead."""
+    ids: set[PydanticObjectId] = set()
+
+    edges = await GroupMembership.find(
+        GroupMembership.site.id == site.id,
+    ).to_list()
+    ids |= {link_target_id(e.group) for e in edges}
+
+    ids |= _sticky_group_ids(site)
+
+    accounts = await SlurmAccount.find(
+        SlurmAccount.site.id == site.id,
+    ).to_list()
+    ids |= {link_target_id(a.group) for a in accounts}
+
+    storages = await Storage.find(Storage.site.id == site.id).to_list()
+    ids |= {link_target_id(s.group) for s in storages}
+
+    user_ids = await _users_at_site_ids(site)
+    if user_ids:
+        users = await User.find(In(User.id, list(user_ids))).to_list()
+        personal = await Group.find(
+            In(Group.name, [u.name for u in users]),
+            Group.type == 'user',
+        ).to_list()
+        ids |= {g.id for g in personal}
+
+    ids.discard(None)
+    if ids:
+        groups = await Group.find(
+            In(Group.id, list(ids)), with_children=True,
+        ).to_list()
+        ids = {
+            g.id for g in groups
+            if not isinstance(g, (AccessGroup, StatusGroup))
+        }
+    return ids
 
 
 async def find_group_by_name(
@@ -185,6 +245,20 @@ async def effective_user_groups(
         group_ids |= sticky_ids
     else:
         sticky_ids = set()
+    group_ids.discard(None)
+
+    # Presence gate: only groups attached to the site (GroupSiteInfo) are
+    # projected there — an edge or sticky ref to a detached group must not
+    # resurrect its LDAP entry. Scoped In() query: O(user's groups), not
+    # O(site's groups).
+    if group_ids:
+        gsis = await GroupSiteInfo.find(
+            In(GroupSiteInfo.group.id, list(group_ids)),
+            GroupSiteInfo.site.id == site.id,
+        ).to_list()
+        present = {link_target_id(g.group) for g in gsis}
+        group_ids &= present
+        sticky_ids &= present
 
     groups = (
         await Group.find(In(Group.id, list(group_ids))).to_list()
@@ -247,6 +321,7 @@ class GroupRefs:
     shared by `DeleteGroup`'s cascade and the CLI's deletion preview."""
 
     memberships: list
+    site_infos: list
     storages: list
     storage_volumes: list
     slurm_accounts: list
@@ -257,6 +332,7 @@ class GroupRefs:
     def counts(self) -> dict[str, int]:
         return {
             'group_memberships': len(self.memberships),
+            'group_site_infos': len(self.site_infos),
             'storages': len(self.storages),
             'storage_volumes': len(self.storage_volumes),
             'slurm_accounts': len(self.slurm_accounts),
@@ -274,6 +350,10 @@ async def gather_group_references(group: Group) -> GroupRefs:
     the group."""
     memberships = await GroupMembership.find(
         GroupMembership.group.id == group.id,
+    ).to_list()
+
+    site_infos = await GroupSiteInfo.find(
+        GroupSiteInfo.group.id == group.id,
     ).to_list()
 
     storages = await Storage.find(Storage.group.id == group.id).to_list()
@@ -312,7 +392,7 @@ async def gather_group_references(group: Group) -> GroupRefs:
     ).to_list()
 
     return GroupRefs(
-        memberships=memberships,
+        memberships=memberships, site_infos=site_infos,
         storages=storages, storage_volumes=storage_volumes,
         slurm_accounts=slurm_accounts,
         slurm_associations=slurm_associations,
@@ -328,18 +408,11 @@ async def _gids_with_type(type_str: str) -> set[PydanticObjectId]:
 
 
 async def _gids_at_site(sitename: str) -> set[PydanticObjectId]:
-    """Groups present at a site: any membership edge there, plus the
-    site's sticky groups."""
+    """Groups present at a site: exactly the `GroupSiteInfo` records."""
     site = await Site.find_one(Site.name == sitename)
     if site is None:
         return set()
-    edges = await GroupMembership.find(
-        GroupMembership.site.id == site.id,
-    ).to_list()
-    ids = {link_target_id(e.group) for e in edges}
-    ids |= _sticky_group_ids(site)
-    ids.discard(None)
-    return ids
+    return await site_present_group_ids(site)
 
 
 async def _gids_with_user(

--- a/cheeto/queries/puppet_legacy.py
+++ b/cheeto/queries/puppet_legacy.py
@@ -40,6 +40,7 @@ from ..puppet import (
     PuppetUserRecord,
 )
 from ..utils import removed_nones
+from .group import site_present_group_ids
 from .storage import list_automap_storages_grouped
 from .user import effective_access_links
 
@@ -119,12 +120,10 @@ async def site_to_puppet_legacy(site: Site) -> PuppetAccountMap:
         GroupMembership.site.id == site.id,
     ).to_list()
 
-    # Sponsor edges may reference users who aren't present at the site
-    # (no UserSiteInfo); v1 emitted sponsor usernames regardless. So we
-    # collect every group id referenced by any edge, plus sticky groups.
-    referenced_group_ids = {link_target_id(e.group) for e in edges}
-    referenced_group_ids |= sticky_group_ids
-    referenced_group_ids.discard(None)
+    # Which groups exist at this site is authoritative: exactly the
+    # GroupSiteInfo records. Edges only drive the member/sudoer/sponsor
+    # attribution below — an edge to a detached group no longer renders.
+    referenced_group_ids = await site_present_group_ids(site)
 
     raw_groups = (
         await Group.find(
@@ -153,11 +152,18 @@ async def site_to_puppet_legacy(site: Site) -> PuppetAccountMap:
     for s in automap_storages.get('group', []):
         gid = link_target_id(s.group)
         storages_by_group_id.setdefault(gid, []).append(s)
-        # v1 exported every SiteGroup; a group whose only site presence is
-        # its storage must still appear in the group map.
+        # A storage-owning group should always carry a GroupSiteInfo (the
+        # provisioning ops ensure one); include strays so the export stays
+        # v1-correct, but surface the drift.
         if gid not in group_by_id and not isinstance(
             s.group, (AccessGroup, StatusGroup),
         ):
+            logger.warning(
+                'Group %s owns storage %s at %s but has no GroupSiteInfo; '
+                'including in export — run `ng group backfill-sites` or '
+                '`ng group add site`',
+                s.group.name, s.name, site.name,
+            )
             group_by_id[gid] = s.group
             candidate_groups.append(s.group)
 
@@ -165,9 +171,9 @@ async def site_to_puppet_legacy(site: Site) -> PuppetAccountMap:
         automap_storages.get('share', []), key=lambda s: s.name,
     )
 
-    # Groups with a slurm account at this site are site-present even with
-    # no member edges (v1 had a SiteGroup for every sponsor group with an
-    # account); they must appear in the group map.
+    # An account-owning group should always carry a GroupSiteInfo (the
+    # slurm ops ensure one); include strays so the export stays v1-correct,
+    # but surface the drift.
     slurm_accounts = await SlurmAccount.find(
         SlurmAccount.site.id == site.id,
         fetch_links=True,
@@ -178,6 +184,12 @@ async def site_to_puppet_legacy(site: Site) -> PuppetAccountMap:
         if g.id not in group_by_id and not isinstance(
             g, (AccessGroup, StatusGroup),
         ):
+            logger.warning(
+                'Group %s owns a SlurmAccount at %s but has no '
+                'GroupSiteInfo; including in export — run `ng group '
+                'backfill-sites` or `ng group add site`',
+                g.name, site.name,
+            )
             group_by_id[g.id] = g
             candidate_groups.append(g)
 

--- a/cheeto/queries/site.py
+++ b/cheeto/queries/site.py
@@ -42,10 +42,12 @@ def _build_site_linked_models() -> list[tuple[str, type]]:
     from ..models.storage import AutomountMap, StaticMount, Storage, StorageVolume
     from ..models.user_site_info import UserSiteInfo
     from ..models.group_membership import GroupMembership
+    from ..models.group_site_info import GroupSiteInfo
     from ..models.hippo import HippoEvent
     return [
         ('user_site_info', UserSiteInfo),
         ('group_membership', GroupMembership),
+        ('group_site_info', GroupSiteInfo),
         ('slurm_associations', SlurmAssociation),
         ('slurm_qos', SlurmQOS),
         ('slurm_partitions', SlurmPartition),

--- a/cheeto/queries/user.py
+++ b/cheeto/queries/user.py
@@ -16,6 +16,7 @@ from beanie.operators import In
 from ..models.base import link_target_id
 from ..models.group import AccessGroup, Group, StatusGroup
 from ..models.group_membership import GroupMembership
+from ..models.group_site_info import GroupSiteInfo
 from ..models.hippo import HippoEvent
 from ..models.site import Site
 from ..models.slurm import SlurmAccount
@@ -428,6 +429,7 @@ class UserRefs:
     coordinator_accounts: list
     hippo_events: list
     personal_group: Group | None
+    personal_group_site_infos: list
 
     def counts(self) -> dict[str, int]:
         return {
@@ -439,6 +441,7 @@ class UserRefs:
             'slurm_coordinator_seats': len(self.coordinator_accounts),
             'hippo_events': len(self.hippo_events),
             'personal_group': 1 if self.personal_group is not None else 0,
+            'group_site_infos': len(self.personal_group_site_infos),
         }
 
 
@@ -455,6 +458,12 @@ async def gather_user_references(user: User) -> UserRefs:
 
     personal_group = await Group.find_one(
         Group.name == user.name, Group.type == 'user',
+    )
+    personal_group_site_infos = (
+        await GroupSiteInfo.find(
+            GroupSiteInfo.group.id == personal_group.id,
+        ).to_list()
+        if personal_group is not None else []
     )
 
     storages = await Storage.find(Storage.owner.id == user.id).to_list()
@@ -488,4 +497,5 @@ async def gather_user_references(user: User) -> UserRefs:
         storages=storages, storage_volumes=storage_volumes,
         coordinator_accounts=coordinator_accounts,
         hippo_events=hippo_events, personal_group=personal_group,
+        personal_group_site_infos=personal_group_site_infos,
     )

--- a/cheeto/tests/test_beanie.py
+++ b/cheeto/tests/test_beanie.py
@@ -22,6 +22,7 @@ from ..models.site import Site
 from ..models.user import UCDIAMInfo, User, SshKey
 from ..models.group import Group
 from ..models.group_membership import GroupMembership
+from ..models.group_site_info import GroupSiteInfo
 from ..models.slurm import (
     SlurmAccount,
     SlurmAccountLimits,
@@ -1259,6 +1260,20 @@ class TestCreateClassUsersOp:
         ).to_list()
         assert all(e.roles == ['member'] for e in edges)
 
+        # Presence records: one for the class group, one per personal group.
+        assert await GroupSiteInfo.find(
+            GroupSiteInfo.group.id == group.id,
+            GroupSiteInfo.site.id == site.id,
+        ).count() == 1
+        for user, _ in results:
+            personal = await Group.find_one(
+                Group.name == user.name, Group.type == 'user',
+            )
+            assert await GroupSiteInfo.find(
+                GroupSiteInfo.group.id == personal.id,
+                GroupSiteInfo.site.id == site.id,
+            ).count() == 1
+
     async def test_nonexistent_site_and_group(self, beanie_client):
         with pytest.raises(ValueError, match='Site .* does not exist'):
             await CreateClassUsers.run(
@@ -1611,6 +1626,14 @@ class TestSiteUserOps:
         assert fetched.status is not None
         assert fetched.status.status_name == 'active'
 
+        # The personal group followed its owner onto the site.
+        personal = await Group.find_one(
+            Group.name == 'siteuser', Group.type == 'user',
+        )
+        assert await GroupSiteInfo.find(
+            GroupSiteInfo.group.id == personal.id,
+        ).count() == 1
+
         await RemoveSiteUser.run(
             beanie_client, None,
             user_name='siteuser', site_name='susite',
@@ -1619,6 +1642,10 @@ class TestSiteUserOps:
             UserSiteInfo.user.id == user.id,
         )
         assert fetched is None
+        # ...and left with them (no home storage at the site).
+        assert await GroupSiteInfo.find(
+            GroupSiteInfo.group.id == personal.id,
+        ).count() == 0
 
     async def test_add_site_user_duplicate(self, beanie_client):
         user, _ = await CreateUser.run(
@@ -3633,6 +3660,10 @@ class TestSiteToPuppetLegacy:
         await GroupMembership(
             user=user, group=lab, site=site, roles=['member'],
         ).insert()
+        # Presence is GSI-authoritative (production attach paths ensure
+        # these; direct-seeded tests add them explicitly).
+        await GroupSiteInfo(group=primary, site=site).insert()
+        await GroupSiteInfo(group=lab, site=site).insert()
 
         result = await site_to_puppet_legacy(site)
         assert set(result.user.keys()) == {'puppet_alice'}
@@ -3668,6 +3699,7 @@ class TestSiteToPuppetLegacy:
         await user.insert()
         sticky_g = Group(name='pl_sticky', gid=61001)
         await sticky_g.insert()  # bob is NOT in members
+        await GroupSiteInfo(group=sticky_g, site=site).insert()
 
         await UserSiteInfo(
             user=user, site=site,
@@ -3824,6 +3856,7 @@ class TestSiteToPuppetLegacy:
 
         lab = Group(name='pl_lab', gid=61003)
         await lab.insert()
+        await GroupSiteInfo(group=lab, site=site).insert()
         await GroupMembership(
             user=member, group=lab, site=site, roles=['member'],
         ).insert()
@@ -3906,6 +3939,8 @@ class TestSiteToPuppetLegacyStorage:
         await GroupMembership(
             user=user, group=lab, site=site, roles=['member'],
         ).insert()
+        await GroupSiteInfo(group=primary, site=site).insert()
+        await GroupSiteInfo(group=lab, site=site).insert()
         return site, user, primary, lab
 
     @staticmethod
@@ -4156,6 +4191,7 @@ class TestSyncUserToLDAPMembership:
         ).insert()
         lab = Group(name='labgrp', gid=71000)
         await lab.insert()
+        await GroupSiteInfo(group=lab, site=site).insert()
         await GroupMembership(
             user=user, group=lab, site=site, roles=['member'],
         ).insert()
@@ -4192,6 +4228,27 @@ class TestSyncUserToLDAPMembership:
 
         assert result.extra['removed_groups'] == ['oldgrp']
         assert 'labgrp' not in result.extra['removed_groups']
+
+    async def test_detached_group_membership_removed(self, beanie_client):
+        # The membership edge survives but the group's GroupSiteInfo is
+        # gone: presence is authoritative, so the reconcile strips the
+        # user's memberUid instead of fighting the eventual prune.
+        user, site, lab = await self._seed_user_on_site()
+        gsi = await GroupSiteInfo.find_one(
+            GroupSiteInfo.group.id == lab.id,
+            GroupSiteInfo.site.id == site.id,
+        )
+        await gsi.delete()
+        ldap = _FakeLDAPManager(
+            {'labgrp', 'login-ssh-users', 'active-users'},
+        )
+
+        result = await SyncUserToLDAP.run(
+            beanie_client, None,
+            username='ldapu', sitename='ldapsite', ldap=ldap,
+        )
+
+        assert result.extra['removed_groups'] == ['labgrp']
 
     async def test_per_site_status_override_projected(self, beanie_client):
         # Global status 'active', per-site override 'disabled' → the user must
@@ -4666,6 +4723,7 @@ class TestSyncGroupToLDAPGate:
         user, site = await _seed_gate_site()
         group = Group(name='gategrp', gid=74100)
         await group.insert()
+        await GroupSiteInfo(group=group, site=site).insert()
         await GroupMembership(
             user=user, group=group, site=site, roles=['member'],
         ).insert()
@@ -4694,23 +4752,55 @@ class TestSyncGroupToLDAPGate:
         await edge.delete()
         assert (await Group.get(group.id)).ldap.needs_sync('gatesite')
 
-    async def test_no_members_writes_watermark(self, beanie_client):
+    async def test_not_on_site_writes_watermark(self, beanie_client):
+        # No GroupSiteInfo at the site → presence-skipped (steady state,
+        # watermark written so the second pass is clean).
         _, site = await _seed_gate_site()
         group = Group(name='gategrp', gid=74100)
         await group.insert()
         ldap = _FakeLDAPManager()
 
         r1 = await self._sync(beanie_client, ldap)
-        assert r1.outcome == 'skipped_no_members_on_site'
+        assert r1.outcome == 'skipped_not_on_site'
+        assert ldap.group_writes == []
+        r2 = await self._sync(beanie_client, ldap)
+        assert r2.outcome == 'skipped_clean'
+
+    async def test_not_on_site_skipped_even_with_force(self, beanie_client):
+        # force/full override dirtiness, never presence.
+        _, site = await _seed_gate_site()
+        await Group(name='gategrp', gid=74100).insert()
+        ldap = _FakeLDAPManager()
+
+        r = await self._sync(beanie_client, ldap, force=True)
+        assert r.outcome == 'skipped_not_on_site'
+        assert ldap.group_writes == []
+
+    async def test_empty_group_written_when_on_site(self, beanie_client):
+        # A present group (GroupSiteInfo) with zero members on the site is
+        # written as an empty entry — the analogue of a user with a USI
+        # and no group memberships.
+        _, site = await _seed_gate_site()
+        group = Group(name='gategrp', gid=74100)
+        await group.insert()
+        await GroupSiteInfo(group=group, site=site).insert()
+        ldap = _FakeLDAPManager()
+
+        r1 = await self._sync(beanie_client, ldap)
+        assert r1.outcome == 'membership_diffed'
+        assert 'gategrp' in ldap.group_writes
+        assert r1.extra['member_count'] == 0
         r2 = await self._sync(beanie_client, ldap)
         assert r2.outcome == 'skipped_clean'
 
     async def test_user_group_synced_without_members(self, beanie_client):
-        # A personal group (type='user', same name+gid as its owner) has no
-        # member edges, but must still be projected because its owner is on
-        # the site.
+        # A personal group (type='user') has no member edges, but is
+        # projected wherever it has a GroupSiteInfo (created by
+        # AddSiteUser/home provisioning for its owner's sites).
         user, site = await _seed_gate_site()
-        await Group(name=user.name, gid=user.uid, type='user').insert()
+        personal = Group(name=user.name, gid=user.uid, type='user')
+        await personal.insert()
+        await GroupSiteInfo(group=personal, site=site).insert()
         ldap = _FakeLDAPManager()
 
         r1 = await self._sync(beanie_client, ldap, groupname=user.name)
@@ -4722,7 +4812,8 @@ class TestSyncGroupToLDAPGate:
         assert r2.outcome == 'skipped_clean'
 
     async def test_user_group_skipped_when_owner_absent(self, beanie_client):
-        # A personal group whose owner is NOT on the site is still skipped.
+        # A personal group with no GroupSiteInfo at the site (owner never
+        # added there) is presence-skipped.
         await _seed_gate_site()
         offsite = User(
             name='offsite_u', email='offsite_u@x.test', uid=74050, gid=74050,
@@ -4734,7 +4825,7 @@ class TestSyncGroupToLDAPGate:
         ldap = _FakeLDAPManager()
 
         r = await self._sync(beanie_client, ldap, groupname='offsite_u')
-        assert r.outcome == 'skipped_no_members_on_site'
+        assert r.outcome == 'skipped_not_on_site'
         assert ldap.group_writes == []
 
     async def test_special_group_no_watermark(self, beanie_client):
@@ -4807,6 +4898,7 @@ class TestSyncSiteLDAPIncremental:
         ).insert()
         group = Group(name='gategrp', gid=74100)
         await group.insert()
+        await GroupSiteInfo(group=group, site=site).insert()
         await GroupMembership(
             user=user, group=group, site=site, roles=['member'],
         ).insert()
@@ -4956,6 +5048,7 @@ async def _seed_slurm_site(with_default=False, partition_name='hi',
 
     group = Group(name='sllab', gid=72000)
     await group.insert()
+    await GroupSiteInfo(group=group, site=site).insert()
 
     alice = User(
         name='sl_alice', email='a@sl.test', uid=72001, gid=72001,
@@ -5808,6 +5901,7 @@ class TestDeleteSite:
         assert counts == {
             'user_site_info': 2,
             'group_membership': 2,
+            'group_site_info': 1,
             'slurm_associations': 1,
             'slurm_qos': 1,
             'slurm_partitions': 1,
@@ -8625,6 +8719,11 @@ class TestFindGroups:
         await site_a.insert()
         await site_b.insert()
 
+        # Presence records (production attach paths ensure these).
+        await GroupSiteInfo(group=lab_a, site=site_a).insert()
+        await GroupSiteInfo(group=sticky, site=site_a).insert()
+        await GroupSiteInfo(group=lab_b, site=site_b).insert()
+
         await GroupMembership(
             user=alice, group=lab_a, site=site_a, roles=['member'],
         ).insert()
@@ -8656,6 +8755,26 @@ class TestFindGroups:
         await self._seed(beanie_client)
         names = [g.name for g in await find_groups(site='fga')]
         assert names == ['fg_lab_a', 'fg_sticky']
+
+    async def test_site_filter_is_gsi_authoritative(self, beanie_client):
+        # Presence = GroupSiteInfo, not membership edges: an edge to a
+        # detached group doesn't list it, and a GSI with no edges does.
+        from cheeto.queries import find_groups
+        alice = await self._seed(beanie_client)
+        site_a = await Site.find_one(Site.name == 'fga')
+
+        detached = Group(name='fg_detached', gid=78104)
+        await detached.insert()
+        await GroupMembership(
+            user=alice, group=detached, site=site_a, roles=['member'],
+        ).insert()  # edge but no presence record
+
+        empty = Group(name='fg_empty', gid=78105)
+        await empty.insert()
+        await GroupSiteInfo(group=empty, site=site_a).insert()
+
+        names = [g.name for g in await find_groups(site='fga')]
+        assert names == ['fg_empty', 'fg_lab_a', 'fg_sticky']
 
     async def test_user_filter_and_site_narrowing(self, beanie_client):
         from cheeto.queries import find_groups
@@ -8696,3 +8815,606 @@ class TestFindGroups:
         assert await find_groups(user='nonesuch') == []
         with pytest.raises(ValueError, match='AND or OR'):
             await find_groups(operator='XOR')
+
+
+class TestGroupSiteInfoModel:
+
+    async def _seed(self):
+        site = Site(name='gsisite', fqdn='gsi.test')
+        await site.insert()
+        group = Group(name='gsigrp', gid=79000)
+        await group.insert()
+        return group, site
+
+    async def test_unique_group_site(self, beanie_client):
+        from pymongo.errors import DuplicateKeyError
+        group, site = await self._seed()
+        await GroupSiteInfo(group=group, site=site).insert()
+        with pytest.raises(DuplicateKeyError):
+            await GroupSiteInfo(group=group, site=site).insert()
+
+    async def test_insert_and_delete_touch_group_only(self, beanie_client):
+        group, site = await self._seed()
+        user = User(
+            name='gsiuser', email='gsi@x.test', uid=79001, gid=79001,
+            fullname='GSI User', home_directory='/home/gsiuser',
+        )
+        await user.insert()
+        g_before = (await Group.get(group.id)).ldap.modified_at
+        u_before = (await User.get(user.id)).ldap.modified_at
+
+        gsi = GroupSiteInfo(group=group, site=site)
+        await gsi.insert()
+        g_after = (await Group.get(group.id)).ldap.modified_at
+        assert g_after > g_before
+        assert (await User.get(user.id)).ldap.modified_at == u_before
+
+        await gsi.delete()
+        assert (await Group.get(group.id)).ldap.modified_at > g_after
+
+
+class TestEnsureGroupSite:
+
+    async def test_idempotent(self, beanie_client):
+        from cheeto.operations import ensure_group_site
+        site = Site(name='egs', fqdn='egs.test')
+        await site.insert()
+        group = Group(name='egsgrp', gid=79010)
+        await group.insert()
+
+        first = await ensure_group_site(group, site, None)
+        second = await ensure_group_site(group, site, None)
+        assert first.id == second.id
+        assert await GroupSiteInfo.find(
+            GroupSiteInfo.group.id == group.id,
+        ).count() == 1
+
+
+class TestAddRemoveSiteGroupOps:
+
+    async def _seed(self):
+        site = Site(name='asg', fqdn='asg.test')
+        await site.insert()
+        group = Group(name='asggrp', gid=79020)
+        await group.insert()
+        return group, site
+
+    async def test_add_creates_presence(self, beanie_client):
+        from cheeto.operations import AddSiteGroup
+        group, site = await self._seed()
+        await AddSiteGroup.run(
+            beanie_client, None, group_name='asggrp', site_name='asg',
+        )
+        assert await GroupSiteInfo.find(
+            GroupSiteInfo.group.id == group.id,
+            GroupSiteInfo.site.id == site.id,
+        ).count() == 1
+        hist = await History.find_one(History.op == 'add_site_group')
+        assert hist.changes == {'group': 'asggrp', 'site': 'asg'}
+
+    async def test_add_refusals(self, beanie_client):
+        from cheeto.operations import AddSiteGroup
+        group, site = await self._seed()
+        await Group(name='asg_personal', gid=79021, type='user').insert()
+
+        with pytest.raises(ValueError, match='access/status group'):
+            await AddSiteGroup.run(
+                beanie_client, None,
+                group_name='active-users', site_name='asg',
+            )
+        with pytest.raises(ValueError, match='personal group'):
+            await AddSiteGroup.run(
+                beanie_client, None,
+                group_name='asg_personal', site_name='asg',
+            )
+        with pytest.raises(ValueError, match='does not exist'):
+            await AddSiteGroup.run(
+                beanie_client, None, group_name='ghost', site_name='asg',
+            )
+        with pytest.raises(ValueError, match='does not exist'):
+            await AddSiteGroup.run(
+                beanie_client, None, group_name='asggrp', site_name='ghost',
+            )
+
+        await AddSiteGroup.run(
+            beanie_client, None, group_name='asggrp', site_name='asg',
+        )
+        with pytest.raises(ValueError, match='already on site'):
+            await AddSiteGroup.run(
+                beanie_client, None, group_name='asggrp', site_name='asg',
+            )
+
+    async def test_remove_clean_and_not_on_site(self, beanie_client):
+        from cheeto.operations import AddSiteGroup, RemoveSiteGroup
+        group, site = await self._seed()
+        with pytest.raises(ValueError, match='not on site'):
+            await RemoveSiteGroup.run(
+                beanie_client, None, group_name='asggrp', site_name='asg',
+            )
+        await AddSiteGroup.run(
+            beanie_client, None, group_name='asggrp', site_name='asg',
+        )
+        await RemoveSiteGroup.run(
+            beanie_client, None, group_name='asggrp', site_name='asg',
+        )
+        assert await GroupSiteInfo.find(
+            GroupSiteInfo.group.id == group.id,
+        ).count() == 0
+
+    async def test_remove_edges_need_force(self, beanie_client):
+        from cheeto.operations import RemoveSiteGroup
+        group, site = await self._seed()
+        user = User(
+            name='asguser', email='asg@x.test', uid=79022, gid=79022,
+            fullname='ASG User', home_directory='/home/asguser',
+        )
+        await user.insert()
+        # AddGroupMember creates the edge AND the presence record.
+        await AddGroupMember.run(
+            beanie_client, None,
+            group_name='asggrp', user_name='asguser', site_name='asg',
+        )
+
+        with pytest.raises(ValueError, match='membership edge'):
+            await RemoveSiteGroup.run(
+                beanie_client, None, group_name='asggrp', site_name='asg',
+            )
+        assert await GroupSiteInfo.find(
+            GroupSiteInfo.group.id == group.id,
+        ).count() == 1
+
+        result = await RemoveSiteGroup.run(
+            beanie_client, None,
+            group_name='asggrp', site_name='asg', force=True,
+        )
+        assert result == {'memberships_deleted': 1}
+        assert await GroupMembership.find(
+            GroupMembership.group.id == group.id,
+        ).count() == 0
+        assert await GroupSiteInfo.find(
+            GroupSiteInfo.group.id == group.id,
+        ).count() == 0
+
+    async def test_remove_blockers_beat_force(self, beanie_client):
+        from cheeto.operations import AddSiteGroup, RemoveSiteGroup
+        group, site = await self._seed()
+        await AddSiteGroup.run(
+            beanie_client, None, group_name='asggrp', site_name='asg',
+        )
+
+        # Slurm account blocks even with force.
+        account = SlurmAccount(group=group, site=site)
+        await account.insert()
+        with pytest.raises(ValueError, match='Slurm account'):
+            await RemoveSiteGroup.run(
+                beanie_client, None,
+                group_name='asggrp', site_name='asg', force=True,
+            )
+        await account.delete()
+
+        # Storage blocks even with force.
+        owner = User(
+            name='asgowner', email='asgo@x.test', uid=79023, gid=79023,
+            fullname='ASG Owner', home_directory='/home/asgowner',
+        )
+        await owner.insert()
+        volume = await _seed_volume(site, name='asgvol')
+        storage = Storage(
+            name='asgstor', site=site, category='group',
+            owner=owner, group=group, volume=volume,
+        )
+        await storage.insert()
+        with pytest.raises(ValueError, match='storage records'):
+            await RemoveSiteGroup.run(
+                beanie_client, None,
+                group_name='asggrp', site_name='asg', force=True,
+            )
+        await storage.delete()
+
+        # Sticky reference blocks even with force.
+        site = await Site.find_one(Site.name == 'asg')
+        site.group.sticky = [group.id]
+        await site.save()
+        with pytest.raises(ValueError, match='sticky-group'):
+            await RemoveSiteGroup.run(
+                beanie_client, None,
+                group_name='asggrp', site_name='asg', force=True,
+            )
+
+        # Blocked removals never dropped the presence record.
+        assert await GroupSiteInfo.find(
+            GroupSiteInfo.group.id == group.id,
+        ).count() == 1
+
+
+class TestGroupSiteEnsureOnAttach:
+    """Every attach path materializes a GroupSiteInfo via ensure_group_site."""
+
+    async def _presence_count(self, group, site) -> int:
+        return await GroupSiteInfo.find(
+            GroupSiteInfo.group.id == group.id,
+            GroupSiteInfo.site.id == site.id,
+        ).count()
+
+    @pytest.mark.parametrize('opcls', [
+        AddGroupMember, AddGroupSponsor, AddGroupSudoer, AddGroupSlurmer,
+    ])
+    async def test_role_add_ensures_presence(self, beanie_client, opcls):
+        site = Site(name='gsat', fqdn='gsat.test')
+        await site.insert()
+        group = Group(name='gsatgrp', gid=79100)
+        await group.insert()
+        user = User(
+            name='gsatu', email='gsat@x.test', uid=79101, gid=79101,
+            fullname='GSAT User', home_directory='/home/gsatu',
+        )
+        await user.insert()
+
+        await opcls.run(
+            beanie_client, None,
+            group_name='gsatgrp', user_name='gsatu', site_name='gsat',
+        )
+        assert await self._presence_count(group, site) == 1
+
+    async def test_create_group_from_sponsor(self, beanie_client):
+        site = Site(name='gsat', fqdn='gsat.test')
+        await site.insert()
+        sponsor = User(
+            name='gsatpi', email='pi@x.test', uid=79102, gid=79102,
+            fullname='GSAT PI', home_directory='/home/gsatpi',
+        )
+        await sponsor.insert()
+
+        group = await CreateGroupFromSponsor.run(
+            beanie_client, None, sponsor_name='gsatpi', site_name='gsat',
+        )
+        assert await self._presence_count(group, site) == 1
+
+    async def test_add_sticky_group_heals(self, beanie_client):
+        from cheeto.operations import AddStickyGroup
+        site = Site(name='gsat', fqdn='gsat.test')
+        await site.insert()
+        group = Group(name='gsatgrp', gid=79100)
+        await group.insert()
+
+        await AddStickyGroup.run(
+            beanie_client, None, sitename='gsat', groupname='gsatgrp',
+        )
+        assert await self._presence_count(group, site) == 1
+
+        # Re-running the (idempotent) sticky add heals a lost record.
+        gsi = await GroupSiteInfo.find_one(GroupSiteInfo.group.id == group.id)
+        await gsi.delete()
+        await AddStickyGroup.run(
+            beanie_client, None, sitename='gsat', groupname='gsatgrp',
+        )
+        assert await self._presence_count(group, site) == 1
+
+    async def test_create_slurm_account(self, beanie_client):
+        from cheeto.operations import CreateSlurmAccount
+        site = Site(name='gsat', fqdn='gsat.test')
+        await site.insert()
+        group = Group(name='gsatgrp', gid=79100)
+        await group.insert()
+
+        await CreateSlurmAccount.run(
+            beanie_client, None, site_name='gsat', group_name='gsatgrp',
+        )
+        assert await self._presence_count(group, site) == 1
+
+    async def test_provision_allocation_autocreates(self, beanie_client):
+        site = await _seed_slurm_site()
+        group = Group(name='provgrp', gid=72100)
+        await group.insert()
+
+        await ProvisionSlurmAllocation.run(
+            beanie_client, None,
+            site_name='slsite', account_group_name='provgrp',
+            partition_name='hi',
+        )
+        assert await self._presence_count(group, site) == 1
+
+    async def test_group_storage(self, beanie_client):
+        site = Site(name='gsat', fqdn='gsat.test')
+        await site.insert()
+        await _seed_volume(site, name='groups', host_path='/nas/groups')
+        await AutomountMap(name='group', site=site, prefix='/group').insert()
+        group = Group(name='gsatgrp', gid=79100)
+        await group.insert()
+        owner = User(
+            name='gsatown', email='own@x.test', uid=79103, gid=79103,
+            fullname='GSAT Owner', home_directory='/home/gsatown',
+        )
+        await owner.insert()
+
+        await CreateGroupStorage.run(
+            beanie_client, None,
+            group_name='gsatgrp', site_name='gsat',
+            quota='1T', parent_volume='groups', owner_name='gsatown',
+        )
+        assert await self._presence_count(group, site) == 1
+
+    async def test_home_storage_personal_group(self, beanie_client):
+        from cheeto.operations import SetSiteStorageDefaults
+        site = Site(name='gsat', fqdn='gsat.test')
+        await site.insert()
+        await _seed_volume(site, name='home', host_path='/nas/home')
+        await AutomountMap(name='home', site=site, prefix='/home').insert()
+        await SetSiteStorageDefaults.run(
+            beanie_client, None, sitename='gsat',
+            home_volume='home', home_quota='20G', home_automount_map='home',
+        )
+        await CreateUser.run(
+            beanie_client, None,
+            name='gsathome', email='home@x.test', uid=79104,
+            fullname='GSAT Home',
+        )
+
+        await CreateHomeStorage.run(
+            beanie_client, None, user_name='gsathome', site_name='gsat',
+        )
+        personal = await Group.find_one(
+            Group.name == 'gsathome', Group.type == 'user',
+        )
+        assert await self._presence_count(personal, site) == 1
+
+
+class TestRemoveSiteUserGSI:
+
+    async def test_kept_while_home_storage_remains(self, beanie_client):
+        from cheeto.operations import SetSiteStorageDefaults
+        site = Site(name='rsg', fqdn='rsg.test')
+        await site.insert()
+        await _seed_volume(site, name='home', host_path='/nas/home')
+        await AutomountMap(name='home', site=site, prefix='/home').insert()
+        await SetSiteStorageDefaults.run(
+            beanie_client, None, sitename='rsg',
+            home_volume='home', home_quota='20G', home_automount_map='home',
+        )
+        await CreateUser.run(
+            beanie_client, None,
+            name='rsguser', email='rsg@x.test', uid=79110,
+            fullname='RSG User',
+        )
+        await AddSiteUser.run(
+            beanie_client, None, user_name='rsguser', site_name='rsg',
+        )
+        await CreateHomeStorage.run(
+            beanie_client, None, user_name='rsguser', site_name='rsg',
+        )
+        personal = await Group.find_one(
+            Group.name == 'rsguser', Group.type == 'user',
+        )
+
+        await RemoveSiteUser.run(
+            beanie_client, None, user_name='rsguser', site_name='rsg',
+        )
+        # USI gone, but presence kept: the home storage still references
+        # the personal group at the site.
+        assert await UserSiteInfo.find_all().count() == 0
+        assert await GroupSiteInfo.find(
+            GroupSiteInfo.group.id == personal.id,
+        ).count() == 1
+        hist = await History.find_one(History.op == 'remove_site_user')
+        assert hist.changes['kept_group_site'] is True
+
+
+class TestBackfillGroupSiteInfo:
+
+    async def _seed(self, beanie_client):
+        site_a = Site(name='bf_a', fqdn='bfa.test')
+        site_b = Site(name='bf_b', fqdn='bfb.test')
+        await site_a.insert()
+        await site_b.insert()
+
+        member = User(
+            name='bf_member', email='bfm@x.test', uid=79200, gid=79200,
+            fullname='BF Member', home_directory='/home/bf_member',
+        )
+        await member.insert()
+        await UserSiteInfo(user=member, site=site_a).insert()
+        # ...and their personal group (imputed via USI presence).
+        await Group(name='bf_member', gid=79200, type='user').insert()
+
+        lab = Group(name='bf_lab', gid=79201)
+        await lab.insert()
+        await GroupMembership(
+            user=member, group=lab, site=site_a, roles=['member'],
+        ).insert()
+
+        sticky = Group(name='bf_sticky', gid=79202)
+        await sticky.insert()
+        site_a.group.sticky = [sticky.id]
+        await site_a.save()
+
+        slurm_grp = Group(name='bf_slurm', gid=79203)
+        await slurm_grp.insert()
+        await SlurmAccount(group=slurm_grp, site=site_a).insert()
+
+        stor_grp = Group(name='bf_storgrp', gid=79204)
+        await stor_grp.insert()
+        volume = await _seed_volume(site_a, name='bfvol')
+        await Storage(
+            name='bf_stor', site=site_a, category='group',
+            owner=member, group=stor_grp, volume=volume,
+        ).insert()
+
+        # Explicit-only presence: no imputed source.
+        extra = Group(name='bf_extra', gid=79205)
+        await extra.insert()
+        await GroupSiteInfo(group=extra, site=site_a).insert()
+
+    async def test_dry_run_reports_without_writing(self, beanie_client):
+        from cheeto.operations import BackfillGroupSiteInfo
+        await self._seed(beanie_client)
+
+        report = await BackfillGroupSiteInfo.run(
+            beanie_client, None, dry_run=True,
+        )
+        assert report['bf_a']['created'] == [
+            'bf_lab', 'bf_member', 'bf_slurm', 'bf_sticky', 'bf_storgrp',
+        ]
+        assert report['bf_a']['existing'] == 1
+        assert report['bf_a']['extras'] == ['bf_extra']
+        assert report['bf_b']['created'] == []
+        # Nothing written: only the pre-existing explicit record remains.
+        assert await GroupSiteInfo.find_all().count() == 1
+
+    async def test_apply_then_idempotent_rerun(self, beanie_client):
+        from cheeto.operations import BackfillGroupSiteInfo
+        await self._seed(beanie_client)
+
+        report = await BackfillGroupSiteInfo.run(beanie_client, None)
+        assert len(report['bf_a']['created']) == 5
+        assert await GroupSiteInfo.find_all().count() == 6
+
+        hist = await History.find_one(
+            History.op == 'backfill_group_site_info',
+        )
+        assert hist.changes['sites']['bf_a'] == {
+            'created': 5, 'existing': 1, 'extras': 1,
+        }
+
+        rerun = await BackfillGroupSiteInfo.run(beanie_client, None)
+        assert rerun['bf_a']['created'] == []
+        assert rerun['bf_a']['existing'] == 6
+        assert rerun['bf_a']['extras'] == ['bf_extra']
+        assert await GroupSiteInfo.find_all().count() == 6
+
+    async def test_site_scoping(self, beanie_client):
+        from cheeto.operations import BackfillGroupSiteInfo
+        await self._seed(beanie_client)
+
+        report = await BackfillGroupSiteInfo.run(
+            beanie_client, None, site_name='bf_b',
+        )
+        assert set(report) == {'bf_b'}
+        # bf_a untouched (still just the explicit record).
+        assert await GroupSiteInfo.find_all().count() == 1
+
+        with pytest.raises(ValueError, match='does not exist'):
+            await BackfillGroupSiteInfo.run(
+                beanie_client, None, site_name='ghost',
+            )
+
+
+class _FakePruneLDAP:
+    """Just enough surface for PruneSiteLDAP's groups phase."""
+
+    def __init__(self, groupnames):
+        self._groups = list(groupnames)
+        self.deleted_groups: list[str] = []
+
+    async def list_groups(self):
+        from types import SimpleNamespace
+        return [SimpleNamespace(groupname=g) for g in self._groups]
+
+    async def delete_group(self, groupname: str) -> None:
+        self.deleted_groups.append(groupname)
+
+
+class TestPruneSiteLDAPGroups:
+
+    async def test_detached_pruned_present_and_special_kept(
+        self, beanie_client,
+    ):
+        from cheeto.operations import PruneSiteLDAP
+        site = Site(name='prsite', fqdn='pr.test')
+        await site.insert()
+        keep = Group(name='pr_keep', gid=79300)
+        await keep.insert()
+        await GroupSiteInfo(group=keep, site=site).insert()
+
+        ldap = _FakePruneLDAP(['pr_keep', 'pr_goner', 'active-users'])
+        plan = await PruneSiteLDAP.run(
+            beanie_client, None,
+            sitename='prsite', ldap=ldap, scope=['groups'], dry_run=True,
+        )
+        assert plan['groups'] == ['pr_goner']
+
+    async def test_ignored_group_kept(self, beanie_client):
+        from cheeto.operations import PruneSiteLDAP
+        site = Site(name='prsite', fqdn='pr.test')
+        await site.insert()
+        keep = Group(name='pr_keep', gid=79300)
+        await keep.insert()
+        await GroupSiteInfo(group=keep, site=site).insert()
+        ignored = Group(name='pr_ignored', gid=79301)
+        ignored.ldap.ignore = True
+        await ignored.insert()
+
+        ldap = _FakePruneLDAP(['pr_keep', 'pr_ignored'])
+        plan = await PruneSiteLDAP.run(
+            beanie_client, None,
+            sitename='prsite', ldap=ldap, scope=['groups'], dry_run=True,
+        )
+        assert plan['groups'] == []
+
+    async def test_aborts_when_backfill_missing(self, beanie_client):
+        from cheeto.ldap_async import LDAPPruneAborted
+        from cheeto.operations import PruneSiteLDAP
+        site = Site(name='prsite', fqdn='pr.test')
+        await site.insert()
+        user = User(
+            name='pruser', email='pr@x.test', uid=79302, gid=79302,
+            fullname='PR User', home_directory='/home/pruser',
+        )
+        await user.insert()
+        group = Group(name='pr_lab', gid=79303)
+        await group.insert()
+        # Membership edges but zero presence records: the backfill hasn't
+        # run — pruning would plan a site-wide wipe.
+        await GroupMembership(
+            user=user, group=group, site=site, roles=['member'],
+        ).insert()
+
+        ldap = _FakePruneLDAP(['pr_lab'])
+        with pytest.raises(LDAPPruneAborted, match='backfill-sites'):
+            await PruneSiteLDAP.run(
+                beanie_client, None,
+                sitename='prsite', ldap=ldap, scope=['groups'],
+                dry_run=True,
+            )
+
+
+class TestGroupSiteCascades:
+
+    async def test_delete_group_removes_presence(self, beanie_client):
+        from cheeto.operations import AddSiteGroup, DeleteGroup
+        await CreateSite.run(beanie_client, None, name='cs_a', fqdn='a.test')
+        await CreateSite.run(beanie_client, None, name='cs_b', fqdn='b.test')
+        group = await CreateGroup.run(
+            beanie_client, None, name='cs_grp', gid=79400,
+        )
+        for sitename in ('cs_a', 'cs_b'):
+            await AddSiteGroup.run(
+                beanie_client, None, group_name='cs_grp', site_name=sitename,
+            )
+        assert await GroupSiteInfo.find_all().count() == 2
+
+        result = await DeleteGroup.run(
+            beanie_client, None, name='cs_grp', reason='testing',
+        )
+        assert result['group_site_infos'] == 2
+        assert await GroupSiteInfo.find_all().count() == 0
+
+    async def test_delete_user_removes_personal_presence(self, beanie_client):
+        from cheeto.operations import DeleteUser
+        await CreateUser.run(
+            beanie_client, None,
+            name='cs_user', email='cs@x.test', uid=79401,
+            fullname='CS User',
+        )
+        await CreateSite.run(beanie_client, None, name='cs_a', fqdn='a.test')
+        await CreateSite.run(beanie_client, None, name='cs_b', fqdn='b.test')
+        for sitename in ('cs_a', 'cs_b'):
+            await AddSiteUser.run(
+                beanie_client, None, user_name='cs_user', site_name=sitename,
+            )
+        assert await GroupSiteInfo.find_all().count() == 2
+
+        result = await DeleteUser.run(
+            beanie_client, None, name='cs_user', reason='testing',
+        )
+        assert result['group_site_infos'] == 2
+        assert await GroupSiteInfo.find_all().count() == 0

--- a/cheeto/tests/test_cli_grammar.py
+++ b/cheeto/tests/test_cli_grammar.py
@@ -36,6 +36,7 @@ EXCEPTIONS = {
     ('slurm', 'provision'),
     ('storage', 'rehome'),
     ('group', 'seed-access-status'),
+    ('group', 'backfill-sites'),
     ('user', 'clear-offboarding-site-statuses'),
     ('user', 'redundant-site-statuses'),
 }

--- a/cheeto/tests/test_ldap_async.py
+++ b/cheeto/tests/test_ldap_async.py
@@ -288,6 +288,14 @@ class TestGroupCRUD:
         fetched = await manager.get_group('eng')
         assert fetched.members == {'carol', 'eve'}
 
+        # Replace-with-empty deletes the memberUid attribute entirely; the
+        # entry survives member-less (GSI-present groups with no members on
+        # a site are projected as empty entries).
+        await manager.set_group_members('eng', set())
+        fetched = await manager.get_group('eng')
+        assert fetched is not None
+        assert fetched.members == set()
+
     async def test_list_user_memberships(self, manager, site):
         await manager.add_user(LDAPUserRecord(
             username='frank', email='frank@x.test',


### PR DESCRIPTION
Group presence on a site was imputed from five sources (membership edges, sticky refs, SlurmAccounts, Storage, personal groups of site users) that each reader combined differently. Presence is now an explicit GroupSiteInfo(group, site) document, and it is authoritative.

Model & operations:
- GroupSiteInfo (SiteAssociation subclass): unique (group, site) index, insert/delete hook LDAP-touches the group.
- ensure_group_site(): idempotent attach helper called from every path that ties a group to a site: role adds (all four roles), CreateGroupFromSponsor, AddStickyGroup (heals on re-run), CreateSlurmAccount + the provision auto-create, group/home storage provisioning, AddSiteUser (personal group follows its owner), and CreateClassUsers. The hippo flow is covered via those ops.
- AddSiteGroup / RemoveSiteGroup (`ng group add|remove site`, multi- target): removal hard-blocks on slurm/storage/sticky references even with --force, which only overrides membership edges.
- BackfillGroupSiteInfo (`ng group backfill-sites [--dry-run]`): materializes presence from all previously-imputed sources; reports created/existing/extras per site.

Removal is explicit only: `user remove site` drops the personal group's presence unless home storage remains (kept_group_site in History); DeleteUser/DeleteGroup/DeleteSite cascade GSIs.

Read paths flipped to GSI authority:
- find_groups --site / group list / group show (new `sites` row) / site show (group count).
- SyncSiteLDAP gathers exactly the GSI-holding groups; SyncGroupToLDAP gains `skipped_not_on_site` (presence beats force/full), writes present-but-empty groups as member-less entries, and drops the _owner_present_at_site personal-group special case.
- effective_user_groups gates memberOf by presence so user syncs do not fight prune.
- PruneSiteLDAP now prunes entries for groups detached from the site (access/status and ldap.ignore exempt) and ABORTS if a site has membership edges but zero GSIs - i.e. the backfill has not run.
- puppet-legacy export takes its group set from GSIs, warn-and- including slurm/storage strays so drift is visible but non-fatal.
- ldap_async._patch_member_set deletes the memberUid attribute explicitly when a group empties.

Deploy note: run `cheeto ng group backfill-sites` (dry-run, review, apply) per environment BEFORE re-enabling LDAP sync/prune beats.